### PR TITLE
Parallel Inference World Size Keyword Argument

### DIFF
--- a/src/eagle/tools/inference.py
+++ b/src/eagle/tools/inference.py
@@ -43,6 +43,9 @@ def create_anemoi_config(
         "input": {"dataset": main_config["input_dataset_kwargs"]},
         "runner": main_config.get("runner", "default"),
     }
+    if "world_size" in main_config and config["runner"] == "parallel":
+        config["world_size"] = main_config["world_size"]
+
     if main_config.get("extract_lam", False):
         config["output"] = {
             "extract_lam": {


### PR DESCRIPTION
Catch the keyword argument `world_size` for non-SLURM based parallel inference as described [here](https://anemoi.readthedocs.io/projects/inference/en/latest/inference/parallel.html#running-inference-in-parallel-without-slurm)