### PR TITLE
Bugfix: Remove attrs from derived lead_time

### DIFF
--- a/src/eagle/tools/metrics.py
+++ b/src/eagle/tools/metrics.py
@@ -72,6 +72,7 @@ def postprocess(xds):
     xds["t0"] = xr.DataArray(t0, coords={"t0": t0})
     xds = xds.set_coords("t0")
     xds["lead_time"] = xds["time"] - xds["time"][0]
+    xds["lead_time"].attrs = {} # remove any calendar details from the attributes
     xds["fhr"] = xr.DataArray(
         xds["lead_time"].values.astype("timedelta64[h]").astype(int),
         coords=xds.time.coords,

--- a/src/eagle/tools/spatial.py
+++ b/src/eagle/tools/spatial.py
@@ -24,6 +24,7 @@ def postprocess(xds, keep_t0=None):
         xds["t0"] = xr.DataArray(t0, coords={"t0": t0})
         xds = xds.set_coords("t0")
     xds["lead_time"] = xds["time"] - xds["time"][0]
+    xds["lead_time"].attrs = {} # remove any calendar details from the attributes
     xds["fhr"] = xr.DataArray(
         xds["lead_time"].values.astype("timedelta64[h]").astype(int),
         coords=xds.time.coords,


### PR DESCRIPTION
Was recently unable to store metrics result due to some weird attributes error. It turns out that the lead time variable when computed like this:

```python
xds["lead_time"] = xds["time"] - xds["time"][0]
```

retains the attributes related to the `time` calendar. Since these calendar attributes are actually used to tell xarray how to store the time variables, it causes problems. These attrs are not relevant anymore for lead time, so we remove them. Problem solved...