### PR TITLE
Parallel Inference

### DIFF
--- a/src/eagle/tools/cli.py
+++ b/src/eagle/tools/cli.py
@@ -57,6 +57,14 @@ inference.help = """Runs Anemoi inference pipeline over many initialization date
         extract_lam (bool, optional): If True, extracts and saves only the LAM
             (Limited Area Model) domain from the output. Only used for Nested model configurations.
             Defaults to False.
+        \b
+        use_mpi (bool, optional): If True, distribute initialization dates across MPI ranks.
+            Each rank loads its own copy of the model onto its GPU. Launch with
+            ``srun --ntasks=N --gpus-per-task=1`` to bind one GPU per rank.
+            Cannot be combined with ``runner: parallel``. Defaults to False.
+        \b
+        log_path (str, optional): When using MPI, the directory where per-rank log files
+            are saved. Defaults to "eagle-logs/inference".
     """
 
 

--- a/src/eagle/tools/inference.py
+++ b/src/eagle/tools/inference.py
@@ -1,5 +1,6 @@
 import logging
 
+import numpy as np
 import pandas as pd
 
 from anemoi.inference.config.run import RunConfiguration
@@ -59,15 +60,38 @@ def create_anemoi_config(
     return config
 
 
+def _load_model_once(main_config: dict):
+    """Load the ML model once by creating a temporary runner.
+
+    This avoids reloading the model from disk for every initialization date.
+    The returned model can be injected into subsequent runners via ``preloaded_model``.
+
+    Args:
+        main_config (dict): The main configuration dictionary.
+
+    Returns:
+        torch.nn.Module: The loaded model.
+    """
+    dummy_date = pd.Timestamp(main_config["start_date"])
+    anemoi_config = create_anemoi_config(init_date=dummy_date, main_config=main_config)
+    run_config = RunConfiguration.load(anemoi_config)
+    runner = create_runner(run_config)
+    model = runner.model
+    return model
+
+
 def run_forecast(
     init_date: pd.Timestamp,
     main_config: dict,
+    preloaded_model=None,
 ) -> None:
     """
     Inference pipeline.
 
     Args:
         init_date (str): date of initialization.
+        preloaded_model (torch.nn.Module, optional): A previously loaded model to
+            inject into the runner, avoiding repeated ``torch.load()`` calls.
 
     Returns:
         None -- files saved out to output path.
@@ -78,6 +102,8 @@ def run_forecast(
     )
     run_config = RunConfiguration.load(anemoi_config)
     runner = create_runner(run_config)
+    if preloaded_model is not None:
+        runner.__dict__["model"] = preloaded_model
     runner.execute()
     return
 
@@ -88,15 +114,40 @@ def main(config):
     See ``eagle-tools inference --help`` or cli.py for help
     """
 
+    topo = config["topo"]
+
+    if config["use_mpi"] and config.get("runner", "default") == "parallel":
+        raise ValueError(
+            "Cannot combine use_mpi=True with runner='parallel'. "
+            "MPI date-parallelism and the ParallelRunnerMixin both try to manage "
+            "SLURM process groups, which conflict with each other. "
+            "Use runner='default' when distributing dates across MPI ranks."
+        )
+
     dates = pd.date_range(start=config["start_date"], end=config["end_date"], freq=config["freq"])
+    n_dates = len(dates)
+    n_batches = int(np.ceil(n_dates / topo.size))
 
     logger.info(f"Running Inference")
     logger.info(f"Initial Conditions:\n{dates}")
-    for d in dates:
+
+    logger.info("Loading model")
+    model = _load_model_once(config)
+    logger.info("Model loaded")
+
+    for batch_idx in range(n_batches):
+        date_idx = (batch_idx * topo.size) + topo.rank
+        if date_idx >= n_dates:
+            break
+
+        d = dates[date_idx]
         logger.info(f"Processing {d}")
         run_forecast(
             init_date=d,
             main_config=config,
+            preloaded_model=model,
         )
         logger.info(f"Done with {d}")
+
+    topo.barrier()
     logger.info(f"Done Running Inference")


### PR DESCRIPTION
Similar to other workflows (e.g., metrics, spectra, prewxvx), use mpi to distribute inference over multiple initial conditions at once. Some key features:

* This also adds the change so the model checkpoint is only loaded once per rank... finally!
* This can't work with model sharding since that relies on slurm / mpi. However, that workflow is broken anyway, so ... another day.