### PR TITLE
Fix 10u/10v names

### DIFF
--- a/src/eagle/tools/config/met.yaml
+++ b/src/eagle/tools/config/met.yaml
@@ -26,8 +26,8 @@ metadata_keys:
 
 rename:
   2t_heightAboveGround_0002: 2m_temperature
-  u_10m_heightAboveGround_0010: 10m_zonal_wind
-  v_10m_heightAboveGround_0010: 10m_meridional_wind
+  10u_heightAboveGround_0010: 10m_zonal_wind
+  10v_heightAboveGround_0010: 10m_meridional_wind
   gh_isobaricInhPa_0500: 500hpa_geopotential_height
   t_isobaricInhPa_0850: 850hpa_temperature
   q_isobaricInhPa_0850: 850hpa_specific_humidity


### PR DESCRIPTION
In a [recent wxvx PR](https://github.com/NOAA-GSL/wxvx/pull/112/changes) the names for the 10-meter u and v component of wind variables were changed from `u_10m` / `v_10m` to `10u` / `10v` to correctly conform to ECMWF standards (see [here](https://codes.ecmwf.int/grib/param-db/165) and [here](https://codes.ecmwf.int/grib/param-db/166)). This PR updates `eagle-tools` to reflect this change in the `postwxvx` code.