### PR TITLE
Small: Check before dropping time coordinates

### DIFF
--- a/src/eagle/tools/data.py
+++ b/src/eagle/tools/data.py
@@ -385,7 +385,9 @@ def open_forecast_zarr_dataset(
     if not reshape_cell_to_2d:
         xds = flatten_to_cell(xds)
 
-    xds = xds.drop_vars(["t0", "valid_time"])
+    for key in ["t0", "valid_time"]:
+        if key in xds:
+            xds = xds.drop_vars(key)
 
     if load:
         xds = xds.load()


### PR DESCRIPTION
In some (edge) cases, we only want static variables. In that case, we do not have time variables like t0 and valid_time to drop. So, before dropping these coordinates, we need to check if they are indeed there.