### PR TITLE
Utils: Unpack "path" instances in config recursively

### DIFF
--- a/src/eagle/tools/utils.py
+++ b/src/eagle/tools/utils.py
@@ -25,15 +25,20 @@ def setup(config_filename: str, command: str):
 def open_yaml_config(config_filename: str):
     with open(config_filename, "r") as f:
         config = yaml.safe_load(f)
+    _expand_paths(config)
+    return config
 
-    # expand any environment variables
+
+def _expand_paths(config: dict):
+    """Recursively expand environment variables in string values whose key contains 'path'."""
     for key, val in config.items():
-        if "path" in key:
+        if isinstance(val, dict):
+            _expand_paths(val)
+        elif "path" in key:
             if isinstance(val, str):
                 config[key] = os.path.expandvars(val)
             else:
                 logger.warning(f"Not expanding environment variables in {key} in config, since it could be many different types")
-    return config
 
 def init_topo(config: dict, command: str) -> MPITopology | SerialTopology:
 


### PR DESCRIPTION
In the current code if we have 

```yaml
forecast_path: ${SCRATCH}/my-stuff
big_kwarg_dict:
  another_path: ${SCRATCH}/even-more-stuff
```

then only `forecast_path` will have the SCRATCH environment variable expanded, `big_kwargs_dict["another_path"]` will not get the environment variable expanded.

This PR adds a recursive routine to unpack all values associated with a "key" that has "*path*" in it. That is, it just extends the current code into nested dictionaries.