### PR TITLE
Add scorecard heatmap and violin plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,101 @@ between `start_date` and `end_date` get shown in the movie.
 eagle-tools figures config.yaml
 eagle-tools movies config.yaml
 ```
+
+### Compare Model Performance
+
+Create only two scorecard-style model performance plot types from metric
+NetCDF files: regional improvement heatmaps and all-response violin plots.
+
+```
+eagle-tools performance-heatmap config.yaml
+eagle-tools performance-violin config.yaml
+```
+
+Example config files are included in `src/eagle/tools/config/performance_heatmap.yaml`
+and `src/eagle/tools/config/performance_violin.yaml`.
+These configs use one `input_path` root and one `output_path`; each model only
+needs a directory name for the common scorecard layout. Standard model labels,
+colors, filename patterns, regions, variables, and levels have built-in
+defaults, and can be overridden in YAML when needed.
+
+Expected input layout:
+
+```
+new_data/
+  nested_eagle_global_2025/
+    rmse.convobs.nested-global.nc
+    rmse.convobs.nested-global.conus.nc
+  gfs_2025/
+    rmse.convobs.global.nc
+    rmse.convobs.global.conus.nc
+  aifs_2025/
+  aigfs_2025/
+  nested_eagle_lam_2025/
+    rmse.convobs.nested-lam.nc
+  hrrr_2025/
+    rmse.convobs.lam.nc
+```
+
+Common built-in model keys are `nested_eagle_global`, `nested_eagle_lam`,
+`gfs`, `aifs`, `aigfs`, `ecmwf_ifs`, and `hrrr`.
+
+Minimal config edits:
+
+```
+metric: rmse
+input_path: /path/to/new_data
+output_path: /path/to/plots
+```
+
+By default, all selected models are evaluated on their exact overlapping
+initialization times (`t0`) and forecast hours (`fhr`). This keeps model
+performance comparisons one-to-one even when one model has only a month of data
+and another has a full year.
+
+Optional temporal filters can be added to either config:
+
+```
+require_exact_time_match: true
+start_date: "2025-01-01"
+end_date: "2025-12-31"
+years: [2025]
+months: [1, 2, 12]
+```
+
+Use `years` for one or more years, `months` for one or more months, or
+`start_date` / `end_date` for a precise date window. Filters are applied before
+matching models.
+
+If your model directory names match the defaults, no `models` block is needed.
+If they differ, add only the directory overrides:
+
+```
+models:
+  gfs:
+    directory: my_gfs_scores
+  aifs:
+    directory: my_aifs_scores
+```
+
+For heatmaps, add or remove comparisons by editing `candidate_model` and
+`baseline_model`:
+
+```
+plots:
+  - candidate_model: nested_eagle_global
+    baseline_model: gfs
+```
+
+For violin plots, add or remove models by editing the `models` list:
+
+```
+plots:
+  - regions: [global, conus]
+    lead_hours: [24, 240]
+    models: [nested_eagle_global, gfs, aigfs, aifs]
+```
+
+Output names include plot type, regions, models, metric, and lead range, for
+example `heatmap_regions-global-nh-sh-conus_models-nested_eagle_global-vs-gfs_rmse_d1-d10.png`.
+Violin plots also write a small summary CSV.

--- a/src/eagle/tools/cli.py
+++ b/src/eagle/tools/cli.py
@@ -304,6 +304,124 @@ spectra.help = """Compute the Power Spectrum averaged over all initial condition
             trim from the edges of the forecast dataset. Defaults to None.
     """
 
+@cli.command("performance-heatmap")
+@click.argument('config_file', type=click.Path(exists=True))
+def performance_heatmap(config_file):
+    """
+    Plot regional model-performance improvement heatmaps.
+    """
+    from eagle.tools.performance_heatmap import main
+    main(config_file)
+
+performance_heatmap.help = """Plot regional model-performance improvement heatmaps.
+
+    \b
+    This is one of the two supported scorecard performance plot commands
+    (heatmap and violin). It compares a candidate model against a baseline
+    model using metric NetCDF files, commonly RMSE files from obs_metrics or
+    scorecard workflows. The plot is controlled by a YAML or JSON config file.
+
+    \b
+    Typical use:
+        eagle-tools performance-heatmap src/eagle/tools/config/performance_heatmap.yaml
+
+    \b
+    Built-in model keys:
+        nested_eagle_global, nested_eagle_lam, gfs, aifs, aigfs, ecmwf_ifs, hrrr
+
+    \b
+    Config Args:
+        input_path (str): Root directory containing one subdirectory per model.
+        \b
+        output_path (str): Directory where heatmap PNG files are written.
+        \b
+        models (dict): Model definitions with subdir, label, color, model_type,
+            and file patterns. If subdir is omitted, the model key is used.
+            A full path can still be provided to override input_path.
+            Patterns may use {metric}, {model}, {model_type}, and {region}.
+        \b
+        candidate_model (str): Model key for the model being evaluated.
+        \b
+        baseline_model (str): Model key used as the baseline.
+        \b
+        regions (list[dict]): Regions to plot. Each region needs a key and may
+            include title and aliases for matching region coordinates.
+        \b
+        variables (list[dict]): Variable groups and rows. Each row needs var,
+            label, and levels. Use levels: null for surface variables.
+        \b
+        forecast_hours (list[int], optional): Forecast hours to plot. If omitted,
+            days are converted to 24-hour intervals.
+        \b
+        start_date/end_date (str, optional): Date window for selecting t0 values.
+        \b
+        years/months (list[int], optional): Year and month filters for t0 values.
+        \b
+        require_exact_time_match (bool, optional): If True, compare only exact
+            overlapping t0 and fhr samples across selected models. Defaults to True.
+        \b
+        output (str, optional): Output image filename. If omitted, the filename
+            includes plot type, regions, models, metric, and lead range.
+    """
+
+
+@cli.command("performance-violin")
+@click.argument('config_file', type=click.Path(exists=True))
+def performance_violin(config_file):
+    """
+    Plot model-performance violin comparisons.
+    """
+    from eagle.tools.performance_violin import main
+    main(config_file)
+
+performance_violin.help = """Plot model-performance violin comparisons.
+
+    \b
+    This is one of the two supported scorecard performance plot commands
+    (heatmap and violin). It pools selected variables, levels, lead times, and
+    regions into normalized model-response distributions. It writes a PNG and
+    a summary CSV.
+
+    \b
+    Typical use:
+        eagle-tools performance-violin src/eagle/tools/config/performance_violin.yaml
+
+    \b
+    Built-in model keys:
+        nested_eagle_global, nested_eagle_lam, gfs, aifs, aigfs, ecmwf_ifs, hrrr
+
+    \b
+    Config Args:
+        input_path (str): Root directory containing one subdirectory per model.
+        \b
+        output_path (str): Directory where violin PNG files and summary CSVs are written.
+        \b
+        models (dict): Model definitions with subdir, label, color, model_type,
+            and file patterns. If subdir is omitted, the model key is used.
+            A full path can still be provided to override input_path.
+            Patterns may use {metric}, {model}, {model_type}, and {region}.
+        \b
+        plots (list[dict], optional): One or more violin plot definitions. Each
+            plot controls selected models, regions, lead_hours, title, and output.
+        \b
+        variables (list[dict]): Variable groups and rows. Each row needs var,
+            label, and levels. Use levels: null for surface variables.
+        \b
+        equal_samples (bool, optional): If True, each variable/level uses the
+            same number of samples from each selected model before normalization.
+            Defaults to True.
+        \b
+        start_date/end_date (str, optional): Date window for selecting t0 values.
+        \b
+        years/months (list[int], optional): Year and month filters for t0 values.
+        \b
+        require_exact_time_match (bool, optional): If True, compare only exact
+            overlapping t0 and fhr samples across selected models. Defaults to True.
+        \b
+        output (str, optional): Output image filename. If omitted, the filename
+            includes plot type, regions, models, metric, and lead range.
+    """
+
 @cli.command()
 @click.argument('config_file', type=click.Path(exists=True))
 def figures(config_file):

--- a/src/eagle/tools/config/performance_heatmap.yaml
+++ b/src/eagle/tools/config/performance_heatmap.yaml
@@ -1,0 +1,62 @@
+# Community-friendly scorecard heatmap config.
+# This is one of the only two scorecard plot types added here:
+# heatmap and violin.
+#
+# How to use:
+#   eagle-tools performance-heatmap path/to/this_config.yaml
+#
+# Most users only need to edit input_path and output_path.
+# Add a models: block only if your directory names differ from the defaults.
+#
+# Built-in model keys:
+#   nested_eagle_global, nested_eagle_lam, gfs, aifs, aigfs, ecmwf_ifs, hrrr
+#
+# Expected layout:
+#   input_path/
+#     nested_eagle_global_2025/
+#     gfs_2025/
+#     aifs_2025/
+#     aigfs_2025/
+
+metric: rmse
+input_path: /scratch3/NAGAPE/epic/role-epic/EAGLE/eagle_models_vv/scorecard_system/data/new_data
+output_path: /scratch3/NAGAPE/epic/role-epic/EAGLE/eagle_models_vv/scorecard_system/outputs
+
+# Optional temporal selection. All selected models are matched on the exact
+# same t0 and forecast-hour coordinates after these filters are applied.
+# Use any combination:
+# start_date: "2025-01-01"
+# end_date: "2025-12-31"
+# years: [2025]
+# months: [1, 2, 12]
+require_exact_time_match: true
+
+# The standard model directory names, labels, colors, filename patterns,
+# regions, variables, levels, and forecast hours have built-in defaults.
+# Example directory override:
+# models:
+#   gfs:
+#     directory: my_gfs_scores
+
+plots:
+  # Add/remove heatmap comparisons by editing candidate_model and baseline_model.
+  - name: nested_eagle_global_vs_gfs_regions
+    candidate_model: nested_eagle_global
+    baseline_model: gfs
+    output: heatmap_regions-global-nh-sh-conus_models-nested_eagle_global-vs-gfs_rmse_d1-d10.png
+
+  - name: nested_eagle_global_vs_aifs_regions
+    candidate_model: nested_eagle_global
+    baseline_model: aifs
+    output: heatmap_regions-global-nh-sh-conus_models-nested_eagle_global-vs-aifs_rmse_d1-d10.png
+
+  - name: nested_eagle_global_vs_aigfs_regions
+    candidate_model: nested_eagle_global
+    baseline_model: aigfs
+    output: heatmap_regions-global-nh-sh-conus_models-nested_eagle_global-vs-aigfs_rmse_d1-d10.png
+
+  # Example for an additional built-in model, if ecmwf_ifs_2025 is present:
+  # - name: nested_eagle_global_vs_ecmwf_ifs_regions
+  #   candidate_model: nested_eagle_global
+  #   baseline_model: ecmwf_ifs
+  #   output: heatmap_regions-global-nh-sh-conus_models-nested_eagle_global-vs-ecmwf_ifs_rmse_d1-d10.png

--- a/src/eagle/tools/config/performance_violin.yaml
+++ b/src/eagle/tools/config/performance_violin.yaml
@@ -1,0 +1,57 @@
+# Community-friendly scorecard violin config.
+# This is one of the only two scorecard plot types added here:
+# heatmap and violin.
+#
+# How to use:
+#   eagle-tools performance-violin path/to/this_config.yaml
+#
+# Most users only need to edit input_path and output_path.
+# Add a models: block only if your directory names differ from the defaults.
+#
+# Built-in model keys:
+#   nested_eagle_global, nested_eagle_lam, gfs, aifs, aigfs, ecmwf_ifs, hrrr
+#
+# Expected layout:
+#   input_path/
+#     nested_eagle_global_2025/
+#     nested_eagle_lam_2025/
+#     gfs_2025/
+#     hrrr_2025/
+
+metric: rmse
+input_path: /scratch3/NAGAPE/epic/role-epic/EAGLE/eagle_models_vv/scorecard_system/data/new_data
+output_path: /scratch3/NAGAPE/epic/role-epic/EAGLE/eagle_models_vv/scorecard_system/outputs
+
+# Optional temporal selection. All selected models are matched on the exact
+# same t0 and forecast-hour coordinates after these filters are applied.
+# Use any combination:
+# start_date: "2025-01-01"
+# end_date: "2025-12-31"
+# years: [2025]
+# months: [1, 2, 12]
+require_exact_time_match: true
+
+# The standard model directory names, labels, colors, filename patterns,
+# variables, levels, and region labels have built-in defaults.
+# Example directory override:
+# models:
+#   hrrr:
+#     directory: my_hrrr_scores
+
+plots:
+  # Add/remove models from a violin by editing the models list.
+  - name: all_response_global_conus_all_models_no_hrrr_rmse
+    title: "Forecast RMSE Guidance: All Responses"
+    subtitle: "Global and CONUS | All global models except HRRR | Forecast Hours 24-240"
+    lead_hours: [24, 240]
+    regions: [global, conus]
+    models: [nested_eagle_global, gfs, aigfs, aifs]
+    output: violin_regions-global-conus_models-nested_eagle_global-gfs-aigfs-aifs_rmse_f024-f240.png
+
+  - name: all_response_conus_gfs_nested_hrrr_48h_rmse
+    title: "Forecast RMSE Guidance: All Responses"
+    subtitle: "CONUS only | GFS, Nested-EAGLE CONUS, and HRRR | Forecast Hours 0-48"
+    lead_hours: [0, 48]
+    regions: [conus]
+    models: [nested_eagle_lam, gfs, hrrr]
+    output: violin_regions-conus_models-nested_eagle_lam-gfs-hrrr_rmse_f000-f048.png

--- a/src/eagle/tools/performance_heatmap.py
+++ b/src/eagle/tools/performance_heatmap.py
@@ -1,0 +1,224 @@
+import logging
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eagle.tools.performance_plot_utils import (
+    get_output_path,
+    iter_variable_rows,
+    load_config,
+    matched_mean_series,
+    model_label,
+    model_info,
+    region_info,
+    slug,
+)
+
+logger = logging.getLogger("eagle.tools")
+
+
+def _forecast_hours(plot_config):
+    if "forecast_hours" in plot_config:
+        fhrs = [int(fhr) for fhr in plot_config["forecast_hours"]]
+    else:
+        days = plot_config.get("days", list(range(1, 11)))
+        fhrs = [24 * int(day) for day in days]
+    labels = plot_config.get("xlabels") or [f"D{int(fhr / 24)}" for fhr in fhrs]
+    return fhrs, labels
+
+
+def _default_regions():
+    return ["global", "northern_hemisphere", "southern_hemisphere", "conus"]
+
+
+def _lead_label(fhrs):
+    if all(fhr % 24 == 0 for fhr in fhrs):
+        return f"d{int(fhrs[0] / 24)}-d{int(fhrs[-1] / 24)}"
+    return f"f{fhrs[0]:03d}-f{fhrs[-1]:03d}"
+
+
+def _region_label_for_filename(config, regions):
+    keys = [region_info(config, region)["key"] for region in regions]
+    abbreviations = {
+        "global": "global",
+        "northern_hemisphere": "nh",
+        "southern_hemisphere": "sh",
+        "conus": "conus",
+    }
+    return "-".join(abbreviations.get(key, slug(key)) for key in keys)
+
+
+def _default_output_filename(config, plot_config, fhrs):
+    regions = plot_config.get("regions", _default_regions())
+    region_part = _region_label_for_filename(config, regions)
+    candidate = slug(plot_config["candidate_model"])
+    baseline = slug(plot_config["baseline_model"])
+    metric = slug(plot_config.get("metric", config.get("metric", "rmse")))
+    return f"heatmap_regions-{region_part}_models-{candidate}-vs-{baseline}_{metric}_{_lead_label(fhrs)}.png"
+
+
+def _box_text_color(value, vmax):
+    if not np.isfinite(value) or vmax <= 0:
+        return "black"
+    return "white" if abs(value) >= 0.60 * vmax else "black"
+
+
+def _single_line_model_label(config, model_key):
+    return model_info(config, model_key).get("label", model_label(config, model_key).replace("\n", " "))
+
+
+def _build_region_matrix(config, plot_config, region, rows, fhrs):
+    region = region_info(config, region)
+    metric = plot_config.get("metric", config.get("metric", "rmse"))
+    candidate = plot_config["candidate_model"]
+    baseline = plot_config["baseline_model"]
+    matrix = np.full((len(rows), len(fhrs)), np.nan)
+
+    for idx, row in enumerate(rows):
+        logger.info("Region=%s row=%s", region["key"], row["label"])
+        candidate_vals, baseline_vals = matched_mean_series(
+            config,
+            candidate_model=candidate,
+            baseline_model=baseline,
+            metric=metric,
+            row=row,
+            region=region,
+            fhrs=fhrs,
+        )
+        with np.errstate(invalid="ignore", divide="ignore"):
+            improvement = 100.0 * (baseline_vals - candidate_vals) / baseline_vals
+        improvement[~np.isfinite(improvement)] = np.nan
+        matrix[idx, :] = improvement
+    return matrix
+
+
+def _plot_heatmap(config, plot_config, region_mats, rows, group_breaks, fhrs, xlabels):
+    regions = plot_config.get("regions", _default_regions())
+    nrows = len(rows)
+    ncols = len(fhrs)
+    figsize = plot_config.get("figsize", [21, 10.5])
+    vmin, vmax = plot_config.get("value_range", [-30.0, 30.0])
+
+    fig, axes = plt.subplots(
+        nrows=1,
+        ncols=len(regions),
+        figsize=figsize,
+        sharey=True,
+        squeeze=False,
+        gridspec_kw=plot_config.get(
+            "gridspec",
+            {
+                "left": 0.105,
+                "right": 0.925,
+                "top": 0.86,
+                "bottom": 0.12,
+                "wspace": 0.055,
+            },
+        ),
+    )
+    axes = axes[0]
+
+    candidate = _single_line_model_label(config, plot_config["candidate_model"])
+    baseline = _single_line_model_label(config, plot_config["baseline_model"])
+    title = plot_config.get("title", f"{candidate} vs {baseline} | Global 0.25 degree data")
+    fig.suptitle(title, fontsize=19, fontweight="bold", y=0.975)
+    cmap = plt.get_cmap(plot_config.get("cmap", "RdBu")).copy()
+    cmap.set_bad(plot_config.get("missing_color", "#f2f2f2"))
+
+    im = None
+    for ax, raw_region in zip(axes, regions):
+        region = region_info(config, raw_region)
+        mat = region_mats[region["key"]]
+        im = ax.imshow(
+            mat,
+            aspect="auto",
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            interpolation="nearest",
+        )
+        ax.set_title(region.get("title", region["key"]), fontsize=13, fontweight="bold", pad=12)
+        ax.set_xlim(-0.5, ncols - 0.5)
+        ax.set_ylim(nrows - 0.5, -0.5)
+        ax.set_xticks(np.arange(ncols))
+        ax.set_xticklabels(xlabels, fontsize=8)
+        ax.xaxis.tick_top()
+        ax.tick_params(axis="x", length=0, pad=2)
+        ax.set_xticks(np.arange(-0.5, ncols, 1), minor=True)
+        ax.set_yticks(np.arange(-0.5, nrows, 1), minor=True)
+        ax.grid(which="minor", color="white", linewidth=0.8)
+        ax.tick_params(which="minor", bottom=False, left=False)
+
+        for y in group_breaks:
+            ax.axhline(y, color="#333333", linewidth=1.15)
+
+        if plot_config.get("annotate", True):
+            for ii in range(nrows):
+                for jj in range(ncols):
+                    value = mat[ii, jj]
+                    if np.isfinite(value):
+                        ax.text(
+                            jj,
+                            ii,
+                            f"{value:.1f}",
+                            ha="center",
+                            va="center",
+                            fontsize=6.7,
+                            color=_box_text_color(value, vmax),
+                            clip_on=True,
+                        )
+
+        for spine in ax.spines.values():
+            spine.set_edgecolor("#444444")
+            spine.set_linewidth(0.9)
+
+    axes[0].set_yticks(np.arange(nrows))
+    axes[0].set_yticklabels([row["label"] for row in rows], fontsize=10)
+    axes[0].tick_params(axis="y", length=0, pad=6)
+    for ax in axes[1:]:
+        ax.tick_params(axis="y", labelleft=False, length=0)
+
+    cax = fig.add_axes(plot_config.get("colorbar_axes", [0.945, 0.18, 0.022, 0.70]))
+    cb = fig.colorbar(im, cax=cax)
+    cb.set_label(plot_config.get("colorbar_label", "RMSE improvement (%)"), fontsize=12, rotation=90, labelpad=16)
+    cb.ax.tick_params(labelsize=10)
+
+    footer = plot_config.get("footer")
+    if footer is None:
+        baseline = _single_line_model_label(config, plot_config["baseline_model"])
+        candidate = _single_line_model_label(config, plot_config["candidate_model"])
+        footer = (
+            f"RMSE improvement (%) = 100 x ({baseline} RMSE - {candidate} RMSE) / {baseline} RMSE. "
+            f"Positive values indicate lower RMSE for {candidate}."
+        )
+    fig.text(0.5, 0.055, footer, ha="center", va="center", fontsize=10, color="#333333")
+
+    output_path = get_output_path(config, plot_config)
+    outpng = output_path / plot_config.get("output", _default_output_filename(config, plot_config, fhrs))
+    fig.savefig(outpng, dpi=int(plot_config.get("dpi", config.get("dpi", 200))), bbox_inches="tight")
+    plt.close(fig)
+    logger.info("Wrote %s", outpng)
+
+
+def plot_one(config, plot_config):
+    fhrs, xlabels = _forecast_hours(plot_config)
+    rows, group_breaks = iter_variable_rows(config, plot_config.get("skip_levels", [100]))
+    region_mats = {}
+    for region in plot_config.get("regions", _default_regions()):
+        region = region_info(config, region)
+        logger.info("Building heatmap region panel: %s", region["key"])
+        region_mats[region["key"]] = _build_region_matrix(config, plot_config, region, rows, fhrs)
+    _plot_heatmap(config, plot_config, region_mats, rows, group_breaks, fhrs, xlabels)
+
+
+def main(config):
+    if isinstance(config, str):
+        config = load_config(config)
+
+    plots = config.get("plots") or [config]
+    for plot_config in plots:
+        merged = {**config, **plot_config}
+        plot_one(config, merged)

--- a/src/eagle/tools/performance_plot_utils.py
+++ b/src/eagle/tools/performance_plot_utils.py
@@ -1,0 +1,738 @@
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    yaml = None
+
+logger = logging.getLogger("eagle.tools")
+
+DEFAULT_REGION_DIM_CANDIDATES = [
+    "region",
+    "mask",
+    "vx_mask",
+    "mask_name",
+    "stat_region",
+    "domain",
+    "area",
+]
+
+DEFAULT_FHR_CANDIDATES = [
+    "fhr",
+    "lead",
+    "lead_time",
+    "forecast_hour",
+    "fhour",
+]
+
+DEFAULT_LEVEL_CANDIDATES = [
+    "level",
+    "lev",
+    "pressure",
+    "pressure_level",
+    "plev",
+    "isobaricInhPa",
+]
+
+DEFAULT_MODELS = {
+    "nested_eagle_global": {
+        "label": "Nested-EAGLE-Global (AI)",
+        "plot_label": "Nested-EAGLE",
+        "plot_sublabel": "Global AI",
+        "region_labels": {
+            "global": "Nested-EAGLE\n(Global)",
+            "conus": "Nested-EAGLE\n(CONUS)",
+        },
+        "color": "royalblue",
+        "directory": "nested_eagle_global_2025",
+        "model_type": "nested-global",
+        "global_patterns": [
+            "{metric}.convobs.nested-global.nc",
+            "{metric}.convobs.global.nc",
+        ],
+        "regional_patterns": [
+            "{metric}.convobs.nested-global.{region}.nc",
+            "{metric}.convobs.global.{region}.nc",
+        ],
+    },
+    "nested_eagle_lam": {
+        "label": "Nested-EAGLE-LAM (AI-HR)",
+        "plot_label": "Nested-EAGLE",
+        "plot_sublabel": "LAM AI-HR",
+        "color": "dodgerblue",
+        "directory": "nested_eagle_lam_2025",
+        "default_pattern": "{metric}.convobs.nested-lam.nc",
+    },
+    "gfs": {
+        "label": "GFS",
+        "color": "black",
+        "directory": "gfs_2025",
+        "model_type": "global",
+        "global_pattern": "{metric}.convobs.global.nc",
+        "regional_pattern": "{metric}.convobs.global.{region}.nc",
+    },
+    "aigfs": {
+        "label": "AIGFS",
+        "color": "forestgreen",
+        "directory": "aigfs_2025",
+        "model_type": "global",
+        "global_pattern": "{metric}.convobs.global.nc",
+        "regional_pattern": "{metric}.convobs.global.{region}.nc",
+    },
+    "aifs": {
+        "label": "AIFS",
+        "color": "firebrick",
+        "directory": "aifs_2025",
+        "model_type": "global",
+        "global_pattern": "{metric}.convobs.global.nc",
+        "regional_pattern": "{metric}.convobs.global.{region}.nc",
+    },
+    "ecmwf_ifs": {
+        "label": "ECMWF IFS",
+        "plot_label": "ECMWF IFS",
+        "color": "purple",
+        "directory": "ecmwf_ifs_2025",
+        "model_type": "global",
+        "global_pattern": "{metric}.convobs.global.nc",
+        "regional_pattern": "{metric}.convobs.global.{region}.nc",
+    },
+    "hrrr": {
+        "label": "HRRR",
+        "color": "darkorange",
+        "directory": "hrrr_2025",
+        "default_pattern": "{metric}.convobs.lam.nc",
+    },
+}
+
+DEFAULT_REGIONS = {
+    "global": {
+        "label": "Global",
+        "file_token": "global",
+        "aliases": ["global", "GLOBAL", "all", "ALL"],
+    },
+    "northern_hemisphere": {
+        "label": "Northern Hemisphere",
+        "file_token": "northern_hemisphere",
+        "aliases": ["northern_hemisphere", "northern hemisphere", "north_hemisphere", "nh", "NH", "nhem", "NHEM"],
+    },
+    "southern_hemisphere": {
+        "label": "Southern Hemisphere",
+        "file_token": "southern_hemisphere",
+        "aliases": ["southern_hemisphere", "southern hemisphere", "south_hemisphere", "sh", "SH", "shem", "SHEM"],
+    },
+    "conus": {
+        "label": "CONUS",
+        "file_token": "conus",
+        "aliases": ["conus", "CONUS", "us", "US"],
+    },
+}
+
+DEFAULT_VARIABLES_V2 = {
+    "surface": [
+        {"key": "2m_temperature", "label": "2m Temperature", "units": "K", "enabled": True},
+        {"key": "10m_zonal_wind", "label": "10m Zonal Wind", "units": "m/s", "enabled": True},
+        {"key": "10m_meridional_wind", "label": "10m Meridional Wind", "units": "m/s", "enabled": True},
+        {"key": "10m_wind_speed", "label": "10m Wind Speed", "units": "m/s", "enabled": True},
+    ],
+    "upper": [
+        {"key": "geopotential_height", "label": "Geopotential Height", "units": "m", "levels": [250, 500, 850], "enabled": True},
+        {"key": "zonal_wind", "label": "Zonal Wind", "units": "m/s", "levels": [250, 500, 850], "enabled": True},
+        {"key": "meridional_wind", "label": "Meridional Wind", "units": "m/s", "levels": [250, 500, 850], "enabled": True},
+        {"key": "wind_speed", "label": "Wind Speed", "units": "m/s", "levels": [250, 500, 850], "enabled": True},
+        {"key": "temperature", "label": "Temperature", "units": "K", "levels": [250, 500, 850], "enabled": True},
+        {"key": "specific_humidity", "label": "Specific Humidity", "units": "kg/kg", "levels": [250, 500, 850], "enabled": True},
+    ],
+}
+
+DEFAULT_VARIABLE_ALIASES = {
+    "geopotential_height": ["geopotential_height", "geopotential", "gh", "z"],
+    "zonal_wind": ["zonal_wind", "u_wind", "u_component_of_wind", "u"],
+    "meridional_wind": ["meridional_wind", "v_wind", "v_component_of_wind", "v"],
+    "temperature": ["temperature", "tmp", "t"],
+    "specific_humidity": ["specific_humidity", "q", "spfh"],
+    "wind_speed": ["wind_speed", "wind"],
+    "surface_pressure": ["surface_pressure", "pressure_surface", "sp", "ps"],
+    "10m_zonal_wind": ["10m_zonal_wind", "u10", "10u"],
+    "10m_meridional_wind": ["10m_meridional_wind", "v10", "10v"],
+    "2m_temperature": ["2m_temperature", "t2m", "2t"],
+    "2m_specific_humidity": ["2m_specific_humidity", "q2m", "2m_q"],
+    "10m_wind_speed": ["10m_wind_speed", "wind_speed_10m", "ws10"],
+}
+
+
+def load_config(config_filename: str) -> dict[str, Any]:
+    suffix = Path(config_filename).suffix.lower()
+    with open(config_filename, "r") as f:
+        if suffix == ".json":
+            config = json.load(f)
+        else:
+            if yaml is None:
+                raise ModuleNotFoundError(
+                    "PyYAML is required to read YAML config files. "
+                    "Install pyyaml or use a .json config file."
+                )
+            config = yaml.safe_load(f)
+    _expand_paths(config)
+    return config
+
+
+def _expand_paths(value: Any) -> Any:
+    if isinstance(value, dict):
+        for key, val in value.items():
+            if isinstance(val, str) and "path" in key:
+                value[key] = os.path.expandvars(val)
+            else:
+                _expand_paths(val)
+    elif isinstance(value, list):
+        for item in value:
+            _expand_paths(item)
+    return value
+
+
+def get_output_path(config: dict[str, Any], plot_config: dict[str, Any]) -> Path:
+    output_path = Path(plot_config.get("output_path", config.get("output_path", "outputs")))
+    output_path.mkdir(parents=True, exist_ok=True)
+    return output_path
+
+
+def get_model_path(config: dict[str, Any], model_key: str) -> Path:
+    info = model_info(config, model_key)
+    if "path" in info:
+        return Path(info["path"])
+
+    input_path = Path(config.get("input_path", config.get("data_base")))
+    subdir = info.get("subdir", info.get("directory", model_key))
+    return input_path / subdir
+
+
+def decode_value(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="ignore")
+    return str(value)
+
+
+def normalized_name(value: Any) -> str:
+    return decode_value(value).strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def slug(value: Any) -> str:
+    value = decode_value(value).strip().lower()
+    value = re.sub(r"[^a-z0-9]+", "_", value)
+    return value.strip("_")
+
+
+def find_name(names: list[str], candidates: list[str]) -> str | None:
+    for candidate in candidates:
+        if candidate in names:
+            return candidate
+    return None
+
+
+def model_info(config: dict[str, Any], model_key: str) -> dict[str, Any]:
+    info = dict(DEFAULT_MODELS.get(model_key, {}))
+    info.update(config.get("models", {}).get(model_key, {}))
+    return info
+
+
+def model_label(config: dict[str, Any], model_key: str, region_key: str | None = None) -> str:
+    info = model_info(config, model_key)
+    labels = info.get("region_labels", {})
+    if region_key is not None and region_key in labels:
+        return labels[region_key]
+    if "plot_label" in info:
+        sublabel = info.get("plot_sublabel", "")
+        return f"{info['plot_label']}\n{sublabel}" if sublabel else info["plot_label"]
+    return info.get("label", model_key)
+
+
+def model_color(config: dict[str, Any], model_key: str) -> str:
+    return model_info(config, model_key).get("color", "gray")
+
+
+def region_label(config: dict[str, Any], region: dict[str, Any] | str) -> str:
+    if isinstance(region, dict):
+        return region.get("title") or region.get("label") or region["key"]
+    return config.get("regions", {}).get(region, {}).get("label", region)
+
+
+def region_info(config: dict[str, Any], region: dict[str, Any] | str) -> dict[str, Any]:
+    if isinstance(region, dict):
+        return region
+
+    regions = {**DEFAULT_REGIONS, **config.get("regions", {})}
+    info = regions.get(region, {}) if isinstance(regions, dict) else {}
+    aliases = info.get("aliases", [])
+    file_token = info.get("file_token", region)
+    return {
+        "key": region,
+        "title": info.get("title", info.get("label", region)),
+        "aliases": [region, file_token, *aliases],
+    }
+
+
+def region_aliases(region: dict[str, Any]) -> list[str]:
+    aliases = list(region.get("aliases", []))
+    key = region.get("key")
+    if key is not None:
+        aliases.append(key)
+    return [normalized_name(alias) for alias in aliases]
+
+
+def iter_variable_rows(config: dict[str, Any], skip_levels: list[int] | None = None):
+    skip_levels = set(skip_levels or [])
+    group_breaks = []
+    rows = []
+    if "variables" not in config:
+        variables_v2 = config.get("variables_v2", DEFAULT_VARIABLES_V2)
+        for item in variables_v2.get("surface", []):
+            if item.get("enabled", True):
+                rows.append({"var": item["key"], "label": item.get("label", item["key"]), "levels": None})
+        group_breaks.append(len(rows) - 0.5)
+        for item in variables_v2.get("upper", []):
+            if not item.get("enabled", True):
+                continue
+            for level in item.get("levels", []):
+                if int(level) not in skip_levels:
+                    rows.append({
+                        "var": item["key"],
+                        "label": f"{item.get('label', item['key'])} {int(level)}",
+                        "levels": [int(level)],
+                    })
+            group_breaks.append(len(rows) - 0.5)
+        return rows, group_breaks[:-1]
+
+    for group in config.get("variables", []):
+        for row in group.get("rows", []):
+            levels = row.get("levels")
+            if levels is not None and len(levels) == 1 and int(levels[0]) in skip_levels:
+                continue
+            rows.append(row)
+        group_breaks.append(len(rows) - 0.5)
+    return rows, group_breaks[:-1]
+
+
+def open_dataset(path: Path) -> xr.Dataset:
+    try:
+        return xr.open_dataset(path, engine="netcdf4", decode_timedelta=True)
+    except Exception:
+        return xr.open_dataset(path, decode_timedelta=True)
+
+
+def candidate_files(
+    config: dict[str, Any],
+    model_key: str,
+    region_key: str,
+    metric: str,
+) -> list[Path]:
+    info = model_info(config, model_key)
+    directory = get_model_path(config, model_key)
+    pattern_key = "global_pattern" if region_key == "global" else "regional_pattern"
+    patterns_key = "global_patterns" if region_key == "global" else "regional_patterns"
+    pattern = info.get(pattern_key)
+    patterns = [pattern] if pattern is not None else info.get(patterns_key)
+    if patterns is None:
+        pattern = info.get("default_pattern")
+        patterns = [pattern] if pattern is not None else info.get("default_patterns", info.get("patterns", []))
+
+    files = []
+    for pattern in patterns:
+        rendered = pattern.format(
+            metric=metric,
+            model=model_key,
+            model_type=info.get("model_type", model_key),
+            region=region_key,
+        )
+        files.extend(sorted(directory.glob(rendered)))
+    return sorted(set(files))
+
+
+def find_var(ds: xr.Dataset, config: dict[str, Any], var_key: str) -> str | None:
+    variable_aliases = {**DEFAULT_VARIABLE_ALIASES, **config.get("variable_aliases", {})}
+    aliases = variable_aliases.get(var_key, [var_key])
+    for name in aliases:
+        if name in ds.data_vars:
+            return name
+    return None
+
+
+def normalize_fhr(da: xr.DataArray, config: dict[str, Any]) -> xr.DataArray | None:
+    candidates = config.get("fhr_candidates", DEFAULT_FHR_CANDIDATES)
+    fhr_name = find_name(list(da.coords) + list(da.dims), candidates)
+    if fhr_name is None:
+        return None
+    if fhr_name != "fhr":
+        da = da.rename({fhr_name: "fhr"})
+    values = np.asarray(da["fhr"].values)
+    if np.issubdtype(values.dtype, np.timedelta64):
+        da = da.assign_coords(fhr=(values / np.timedelta64(1, "h")).astype(int))
+    return da
+
+
+def normalize_level(da: xr.DataArray, config: dict[str, Any]) -> tuple[xr.DataArray, str | None]:
+    candidates = config.get("level_candidates", DEFAULT_LEVEL_CANDIDATES)
+    level_name = find_name(list(da.coords) + list(da.dims), candidates)
+    if level_name is None:
+        return da, None
+    if level_name != "level":
+        da = da.rename({level_name: "level"})
+    return da, "level"
+
+
+def select_region(
+    da: xr.DataArray,
+    config: dict[str, Any],
+    region: dict[str, Any],
+    allow_no_region: bool,
+) -> xr.DataArray | None:
+    candidates = config.get("region_dim_candidates", DEFAULT_REGION_DIM_CANDIDATES)
+    region_dim = find_name(list(da.coords) + list(da.dims), candidates)
+    if region_dim is None:
+        return da if allow_no_region else None
+
+    values = [normalized_name(value) for value in da[region_dim].values]
+    aliases = region_aliases(region)
+    for idx, value in enumerate(values):
+        if value in aliases:
+            return da.sel({region_dim: da[region_dim].values[idx]})
+    return None
+
+
+def select_level(
+    da: xr.DataArray,
+    config: dict[str, Any],
+    levels: list[int] | None,
+) -> xr.DataArray | None:
+    da, level_name = normalize_level(da, config)
+    if levels is None:
+        if level_name is not None and "level" in da.dims:
+            return None
+        return da
+
+    if level_name is None:
+        return None
+
+    have = [int(x) for x in da["level"].values]
+    for level in levels:
+        if int(level) in have:
+            return da.sel(level=int(level))
+    return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def temporal_filter_kwargs(config: dict[str, Any]) -> dict[str, Any]:
+    temporal = config.get("temporal", {})
+    return {
+        "start_date": config.get("start_date", temporal.get("start_date")),
+        "end_date": config.get("end_date", temporal.get("end_date")),
+        "years": config.get("years", temporal.get("years")),
+        "months": config.get("months", temporal.get("months")),
+    }
+
+
+def describe_temporal_filter(config: dict[str, Any]) -> str:
+    parts = []
+    kwargs = temporal_filter_kwargs(config)
+    if kwargs["start_date"] is not None:
+        parts.append(f"start_date={kwargs['start_date']}")
+    if kwargs["end_date"] is not None:
+        parts.append(f"end_date={kwargs['end_date']}")
+    if kwargs["years"] is not None:
+        parts.append(f"years={_as_list(kwargs['years'])}")
+    if kwargs["months"] is not None:
+        parts.append(f"months={_as_list(kwargs['months'])}")
+    return ", ".join(parts) if parts else "all available overlapping times"
+
+
+def apply_temporal_filter(da: xr.DataArray, config: dict[str, Any]) -> xr.DataArray:
+    if "t0" not in da.coords:
+        if any(value is not None for value in temporal_filter_kwargs(config).values()):
+            logger.warning("Temporal filtering was requested, but data has no t0 coordinate")
+        return da
+
+    kwargs = temporal_filter_kwargs(config)
+    t0 = da["t0"]
+    mask = xr.ones_like(t0, dtype=bool)
+
+    if kwargs["start_date"] is not None:
+        mask = mask & (t0 >= np.datetime64(kwargs["start_date"]))
+    if kwargs["end_date"] is not None:
+        mask = mask & (t0 <= np.datetime64(kwargs["end_date"]))
+    if kwargs["years"] is not None:
+        years = [int(year) for year in _as_list(kwargs["years"])]
+        mask = mask & t0.dt.year.isin(years)
+    if kwargs["months"] is not None:
+        months = [int(month) for month in _as_list(kwargs["months"])]
+        mask = mask & t0.dt.month.isin(months)
+
+    t0_dims = t0.dims
+    if len(t0_dims) != 1:
+        logger.warning("Cannot apply temporal filter to non-1D t0 coordinate with dims=%s", t0_dims)
+        return da
+
+    dim = t0_dims[0]
+    return da.where(mask, drop=True) if dim not in da.dims else da.isel({dim: mask})
+
+
+def combine_metric_arrays(arrays: list[xr.DataArray]) -> xr.DataArray:
+    if len(arrays) == 1:
+        return arrays[0]
+
+    if all("t0" in arr.dims for arr in arrays):
+        return xr.concat(
+            arrays,
+            dim="t0",
+            coords="minimal",
+            compat="override",
+            join="outer",
+            combine_attrs="drop_conflicts",
+        ).sortby("t0")
+
+    return xr.concat(
+        arrays,
+        dim="sample_file",
+        coords="minimal",
+        compat="override",
+        join="outer",
+        combine_attrs="drop_conflicts",
+    )
+
+
+def align_metric_arrays(
+    arrays: list[xr.DataArray],
+    require_exact_time_match: bool = True,
+) -> list[xr.DataArray]:
+    if not arrays:
+        return []
+
+    join = "inner" if require_exact_time_match else "outer"
+    aligned = xr.align(*arrays, join=join)
+    if require_exact_time_match:
+        if "t0" in aligned[0].sizes and aligned[0].sizes["t0"] == 0:
+            raise ValueError("No overlapping t0 values found across selected models")
+        if "fhr" in aligned[0].sizes and aligned[0].sizes["fhr"] == 0:
+            raise ValueError("No overlapping forecast hours found across selected models")
+    return list(aligned)
+
+
+def apply_common_finite_mask(arrays: list[xr.DataArray]) -> list[xr.DataArray]:
+    if not arrays:
+        return []
+    mask = xr.ones_like(arrays[0], dtype=bool)
+    for da in arrays:
+        mask = mask & np.isfinite(da)
+    return [da.where(mask) for da in arrays]
+
+
+def load_metric_array(
+    config: dict[str, Any],
+    model_key: str,
+    metric: str,
+    variable: str,
+    region: dict[str, Any],
+    level: int | None,
+    fhrs: list[int],
+) -> xr.DataArray | None:
+    files = candidate_files(config, model_key, region["key"], metric)
+    if not files:
+        logger.warning("No files found for model=%s region=%s", model_key, region["key"])
+        return None
+
+    arrays = []
+    allow_no_region = region["key"] == "global"
+    if region["key"] != "global":
+        allow_no_region = True
+
+    for path in files:
+        ds = open_dataset(path)
+        try:
+            ds_var = find_var(ds, config, variable)
+            if ds_var is None:
+                continue
+
+            da = normalize_fhr(ds[ds_var], config)
+            if da is None or "fhr" not in da.coords:
+                continue
+
+            da = select_region(da, config, region, allow_no_region=allow_no_region)
+            if da is None:
+                continue
+
+            levels = None if level is None else [level]
+            da = select_level(da, config, levels)
+            if da is None:
+                continue
+
+            have_fhr = [int(x) for x in da["fhr"].values]
+            use_fhr = [int(fhr) for fhr in fhrs if int(fhr) in have_fhr]
+            if not use_fhr:
+                continue
+
+            da = da.sel(fhr=use_fhr).reindex(fhr=fhrs)
+            arrays.append(da.load())
+        finally:
+            ds.close()
+
+    if not arrays:
+        logger.warning(
+            "No usable data for model=%s region=%s variable=%s level=%s",
+            model_key,
+            region["key"],
+            variable,
+            level,
+        )
+        return None
+
+    return apply_temporal_filter(combine_metric_arrays(arrays), config)
+
+
+def matched_mean_series(
+    config: dict[str, Any],
+    candidate_model: str,
+    baseline_model: str,
+    metric: str,
+    row: dict[str, Any],
+    region: dict[str, Any],
+    fhrs: list[int],
+) -> tuple[np.ndarray, np.ndarray]:
+    levels = row.get("levels")
+    level = None if levels is None else int(levels[0])
+    candidate = load_metric_array(config, candidate_model, metric, row["var"], region, level, fhrs)
+    baseline = load_metric_array(config, baseline_model, metric, row["var"], region, level, fhrs)
+    if candidate is None or baseline is None:
+        missing = np.full(len(fhrs), np.nan)
+        return missing, missing
+
+    candidate, baseline = align_metric_arrays(
+        [candidate, baseline],
+        require_exact_time_match=config.get("require_exact_time_match", True),
+    )
+    candidate, baseline = apply_common_finite_mask([candidate, baseline])
+    mean_dims = [dim for dim in candidate.dims if dim != "fhr"]
+    candidate_vals = np.asarray(candidate.mean(mean_dims, skipna=True).reindex(fhr=fhrs).values, dtype=float).squeeze()
+    baseline_vals = np.asarray(baseline.mean(mean_dims, skipna=True).reindex(fhr=fhrs).values, dtype=float).squeeze()
+    if candidate_vals.shape != (len(fhrs),) or baseline_vals.shape != (len(fhrs),):
+        logger.warning(
+            "Bad matched shape for %s vs %s %s %s: %s %s",
+            candidate_model,
+            baseline_model,
+            region["key"],
+            row["label"],
+            candidate_vals.shape,
+            baseline_vals.shape,
+        )
+        missing = np.full(len(fhrs), np.nan)
+        return missing, missing
+    return candidate_vals, baseline_vals
+
+
+def mean_series(
+    config: dict[str, Any],
+    model_key: str,
+    metric: str,
+    row: dict[str, Any],
+    region: dict[str, Any],
+    fhrs: list[int],
+) -> np.ndarray:
+    levels = row.get("levels")
+    level = None if levels is None else int(levels[0])
+    da = load_metric_array(config, model_key, metric, row["var"], region, level, fhrs)
+    if da is None:
+        return np.full(len(fhrs), np.nan)
+    mean_dims = [dim for dim in da.dims if dim != "fhr"]
+    vals = da.mean(mean_dims, skipna=True).reindex(fhr=fhrs).values
+    vals = np.asarray(vals, dtype=float).squeeze()
+    if vals.shape != (len(fhrs),):
+        logger.warning("Bad shape for %s %s %s: %s", model_key, region["key"], row["label"], vals.shape)
+        return np.full(len(fhrs), np.nan)
+    return vals
+
+
+def response_values(
+    config: dict[str, Any],
+    model_key: str,
+    metric: str,
+    variable: str,
+    region: dict[str, Any],
+    level: int | None,
+    fhrs: list[int],
+) -> np.ndarray:
+    da = load_metric_array(config, model_key, metric, variable, region, level, fhrs)
+    if da is None:
+        return np.array([], dtype=float)
+    vals = np.asarray(da.values, dtype=float).ravel()
+    return vals[np.isfinite(vals)]
+
+
+def matched_response_values(
+    config: dict[str, Any],
+    model_keys: list[str],
+    metric: str,
+    variable: str,
+    region: dict[str, Any],
+    level: int | None,
+    fhrs: list[int],
+) -> dict[str, np.ndarray]:
+    arrays = {}
+    for model_key in model_keys:
+        da = load_metric_array(config, model_key, metric, variable, region, level, fhrs)
+        if da is None:
+            return {}
+        arrays[model_key] = da
+
+    aligned = align_metric_arrays(
+        list(arrays.values()),
+        require_exact_time_match=config.get("require_exact_time_match", True),
+    )
+    aligned = apply_common_finite_mask(aligned)
+    return {
+        model_key: np.asarray(da.values, dtype=float).ravel()
+        for model_key, da in zip(arrays, aligned)
+    }
+
+
+def summarize(vals: np.ndarray) -> dict[str, float | int]:
+    vals = vals[np.isfinite(vals)]
+    if vals.size == 0:
+        return {
+            "count": 0,
+            "mean": np.nan,
+            "median": np.nan,
+            "std": np.nan,
+            "min": np.nan,
+            "max": np.nan,
+        }
+    return {
+        "count": int(vals.size),
+        "mean": float(np.nanmean(vals)),
+        "median": float(np.nanmedian(vals)),
+        "std": float(np.nanstd(vals)),
+        "min": float(np.nanmin(vals)),
+        "max": float(np.nanmax(vals)),
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)

--- a/src/eagle/tools/performance_violin.py
+++ b/src/eagle/tools/performance_violin.py
@@ -1,0 +1,270 @@
+import logging
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from eagle.tools.performance_plot_utils import (
+    get_output_path,
+    iter_variable_rows,
+    load_config,
+    matched_response_values,
+    model_color,
+    model_label,
+    region_label,
+    region_info,
+    slug,
+    summarize,
+    write_csv,
+)
+
+logger = logging.getLogger("eagle.tools")
+
+
+def _forecast_hours(plot_config):
+    lead_start, lead_end = plot_config.get("lead_hours", [24, 240])
+    step = int(plot_config.get("lead_step", 24))
+    return list(range(int(lead_start), int(lead_end) + 1, step))
+
+
+def _default_output_stem(config, plot_config):
+    regions = "-".join(slug(region_info(config, region)["key"]) for region in plot_config["regions"])
+    models = "-".join(slug(model) for model in plot_config["models"])
+    metric = slug(plot_config.get("metric", config.get("metric", "rmse")))
+    lead_start, lead_end = plot_config.get("lead_hours", [24, 240])
+    return f"violin_regions-{regions}_models-{models}_{metric}_f{int(lead_start):03d}-f{int(lead_end):03d}"
+
+
+def _normalized_response_values(config, plot_config, model_key, region, fhrs):
+    region = region_info(config, region)
+    chunks = []
+    metric = plot_config.get("metric", config.get("metric", "rmse"))
+    models = plot_config["models"]
+    equal_samples = bool(plot_config.get("equal_samples", True))
+
+    rows, _ = iter_variable_rows(config, plot_config.get("skip_levels", []))
+    for row in rows:
+        levels = row.get("levels")
+        level = None if levels is None else int(levels[0])
+        raw_by_model = matched_response_values(
+            config,
+            model_keys=models,
+            metric=metric,
+            variable=row["var"],
+            region=region,
+            level=level,
+            fhrs=fhrs,
+        )
+        raw_by_model = {
+            selected_model: vals[np.isfinite(vals)]
+            for selected_model, vals in raw_by_model.items()
+            if vals[np.isfinite(vals)].size > 0
+        }
+
+        if any(selected_model not in raw_by_model for selected_model in models):
+            continue
+
+        if equal_samples:
+            min_count = min(raw_by_model[selected_model].size for selected_model in models)
+            if min_count < 2:
+                continue
+            raw_by_model = {
+                selected_model: raw_by_model[selected_model][:min_count]
+                for selected_model in models
+            }
+
+        pooled = np.concatenate([raw_by_model[selected_model] for selected_model in models])
+        pooled = pooled[np.isfinite(pooled)]
+        if pooled.size == 0:
+            continue
+
+        denom = np.nanmedian(pooled)
+        if not np.isfinite(denom) or denom <= 0:
+            continue
+
+        normalized = raw_by_model[model_key] / denom
+        normalized = normalized[np.isfinite(normalized)]
+        if normalized.size:
+            chunks.append(normalized)
+
+    if not chunks:
+        return np.array([], dtype=float)
+    return np.concatenate(chunks)
+
+
+def _clipped_plot_data(data, good, percentile):
+    all_vals = np.concatenate([data[idx] for idx in good])
+    all_vals = all_vals[np.isfinite(all_vals)]
+    if all_vals.size == 0:
+        return [], 1.0
+
+    cap = float(np.nanpercentile(all_vals, percentile))
+    cap = max(cap, 1.25)
+    plot_data = []
+    for idx in good:
+        vals = data[idx]
+        vals = vals[np.isfinite(vals)]
+        clipped = vals[(vals >= 0.0) & (vals <= cap)]
+        if clipped.size < 2:
+            clipped = vals
+        plot_data.append(clipped)
+    return plot_data, cap
+
+
+def plot_one(config, plot_config):
+    metric = plot_config.get("metric", config.get("metric", "rmse"))
+    regions = plot_config["regions"]
+    models = plot_config["models"]
+    fhrs = _forecast_hours(plot_config)
+    output_path = get_output_path(config, plot_config)
+    dpi = int(plot_config.get("dpi", config.get("dpi", 200)))
+    output_stem = _default_output_stem(config, plot_config)
+    outpng = output_path / plot_config.get("output", f"{output_stem}.png")
+    if "summary_output" in plot_config:
+        outcsv = output_path / plot_config["summary_output"]
+    else:
+        outcsv = output_path / f"{outpng.stem}_summary.csv"
+
+    fig, axes = plt.subplots(
+        len(regions),
+        1,
+        figsize=plot_config.get("figsize", [11.5, 4.9 * len(regions) + 1.2]),
+        squeeze=False,
+    )
+    axes = axes[:, 0]
+    rows = []
+
+    for ax, raw_region in zip(axes, regions):
+        region = region_info(config, raw_region)
+        data = []
+        labels = []
+        colors = []
+        stats = []
+
+        for model_key in models:
+            vals = _normalized_response_values(config, plot_config, model_key, region, fhrs)
+            stat = summarize(vals)
+            logger.info(
+                "%s | %s | %s Count=%s Median=%.3f Mean=%.3f",
+                plot_config["name"],
+                region["key"],
+                model_key,
+                stat["count"],
+                stat["median"],
+                stat["mean"],
+            )
+            data.append(vals)
+            labels.append(model_label(config, model_key, region["key"]))
+            colors.append(model_color(config, model_key))
+            stats.append(stat)
+            rows.append(
+                {
+                    "plot": plot_config["name"],
+                    "region": region["key"],
+                    "model": model_key,
+                    "metric": metric,
+                    "value_type": "normalized_metric_all_responses",
+                    **stat,
+                }
+            )
+
+        positions = np.arange(1, len(models) + 1)
+        good = [idx for idx, vals in enumerate(data) if vals.size > 1]
+        ax.axhline(1.0, color="gray", linewidth=1.0, linestyle="--", alpha=0.55, zorder=0)
+
+        if good:
+            plot_data, cap = _clipped_plot_data(data, good, float(plot_config.get("clip_percentile", 98.5)))
+            vp = ax.violinplot(
+                plot_data,
+                positions=[positions[idx] for idx in good],
+                widths=float(plot_config.get("violin_width", 0.62)),
+                showmeans=False,
+                showmedians=False,
+                showextrema=False,
+            )
+            for body, idx in zip(vp["bodies"], good):
+                body.set_facecolor(colors[idx])
+                body.set_edgecolor("black")
+                body.set_alpha(0.78)
+                body.set_linewidth(1.2)
+
+            ax.boxplot(
+                plot_data,
+                positions=[positions[idx] for idx in good],
+                widths=0.15,
+                whis=(5, 95),
+                showfliers=False,
+                patch_artist=True,
+                boxprops={"facecolor": "white", "edgecolor": "black", "linewidth": 1.1},
+                medianprops={"color": "black", "linewidth": 1.5},
+                whiskerprops={"color": "black", "linewidth": 1.1},
+                capprops={"color": "black", "linewidth": 1.1},
+            )
+            ax.set_ylim(0, cap * float(plot_config.get("ylim_scale", 1.75)))
+
+            for idx in good:
+                x = positions[idx]
+                stat = stats[idx]
+                ax.scatter(
+                    [x],
+                    [min(stat["mean"], cap)],
+                    s=48,
+                    facecolor="white",
+                    edgecolor="black",
+                    linewidth=1.0,
+                    zorder=6,
+                )
+                ax.text(
+                    x,
+                    0.955,
+                    f"Count = {stat['count']}\nMedian = {stat['median']:.2f}",
+                    transform=ax.get_xaxis_transform(),
+                    ha="center",
+                    va="top",
+                    fontsize=8.5,
+                    fontweight="bold",
+                    bbox=dict(facecolor="white", edgecolor="none", alpha=0.95, pad=1.5),
+                )
+                ax.text(
+                    x,
+                    0.825,
+                    f"{stat['mean']:.2f}",
+                    transform=ax.get_xaxis_transform(),
+                    ha="center",
+                    va="top",
+                    fontsize=13,
+                    fontweight="bold",
+                    bbox=dict(facecolor="white", edgecolor="none", alpha=0.95, pad=1.5),
+                )
+
+        ax.set_title(region_label(config, region), fontsize=17, fontweight="bold", pad=6)
+        ax.set_ylabel(plot_config.get("ylabel", "Normalized RMSE\nLower is Better"), fontsize=12)
+        ax.set_xticks(positions)
+        ax.set_xticklabels(labels, fontsize=10)
+        for tick, color in zip(ax.get_xticklabels(), colors):
+            tick.set_color(color)
+            tick.set_fontweight("bold")
+        ax.grid(True, axis="y", linestyle=":", alpha=0.28)
+        ax.set_xlim(0.45, len(models) + 0.55)
+
+    fig.suptitle(plot_config["title"], fontsize=20, fontweight="bold", y=0.990)
+    if plot_config.get("subtitle"):
+        fig.text(0.5, 0.925, plot_config["subtitle"], ha="center", fontsize=12.5)
+    fig.tight_layout(rect=plot_config.get("tight_layout_rect", [0.04, 0.03, 1.0, 0.890]))
+    fig.savefig(outpng, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+    write_csv(outcsv, rows)
+    logger.info("Wrote %s", outpng)
+    logger.info("Wrote %s", outcsv)
+
+
+def main(config):
+    if isinstance(config, str):
+        config = load_config(config)
+
+    plots = config.get("plots") or [config]
+    for plot_config in plots:
+        merged = {**config, **plot_config}
+        plot_one(config, merged)


### PR DESCRIPTION
Requested by Sergey Frolov to add these performance plotting features to `eagle-tools`.

## Summary
- Add two scorecard-style performance plotting commands:
  - `eagle-tools performance-heatmap`
  - `eagle-tools performance-violin`
- Add config-driven regional RMSE improvement heatmaps for model-vs-baseline comparisons.
- Add config-driven all-response violin plots with summary CSV output.
- Include built-in defaults for common scorecard models, regions, variables, levels, aliases, colors, and filename patterns.
- Add community-friendly example YAML configs and README usage instructions.

## Supported Plot Types
This PR intentionally adds only two scorecard performance plot types:
- Heatmap
- Violin

## Usage
```bash
eagle-tools performance-heatmap src/eagle/tools/config/performance_heatmap.yaml
eagle-tools performance-violin src/eagle/tools/config/performance_violin.yaml