### PR TITLE
Fractions Skill Score

### DIFF
--- a/src/eagle/tools/cli.py
+++ b/src/eagle/tools/cli.py
@@ -174,6 +174,88 @@ metrics.help = """Compute grid cell area weighted RMSE and MAE.
 
 @cli.command()
 @click.argument('config_file', type=click.Path(exists=True))
+def fss(config_file):
+    """
+    Compute the Fractions Skill Score.
+    """
+    from eagle.tools.fss import main
+    main(config_file)
+
+fss.help = """Compute the deterministic Fractions Skill Score (FSS).
+
+    \b
+    Implements the neighborhood-based FSS of Roberts & Lean (2008, MWR). For each
+    threshold and neighborhood radius, forecast and verification fields are
+    converted to binary exceedance fields, the fraction of exceeding grid points
+    within a square neighborhood is computed for each grid cell, and
+    FSS = 1 - MSE / MSE_ref, where MSE = mean((M-O)^2) and MSE_ref = mean(M^2+O^2)
+    over the domain (M, O = forecast/observed neighborhood fractions).
+
+    \b
+    Results are stored per initial condition and forecast hour (no averaging over
+    initial conditions), so downstream code can both aggregate correctly
+    (FSS = 1 - sum(mse)/sum(mse_ref) over t0) and estimate statistical significance.
+
+    \b
+    Note:
+        The arguments documented here are passed via a config dictionary.
+
+    \b
+    Config Args:
+        forecast_path (str): Directory containing the forecast NetCDF files, named
+            f"{forecast_path}/{t0}.{lead_time}h.nc".
+        \b
+        output_path (str): Directory where the output is saved, as
+            f"{output_path}/fss.{model_type}.nc". The result has data_vars
+            fss, mse, mse_ref with dims (t0, fhr, threshold, radius).
+        \b
+        lead_time (int): Forecast length in hours, used only to build the forecast
+            filename.
+        \b
+        forecast_hours (list[int]): The specific lead times (hours) at which to
+            compute FSS.
+        \b
+        thresholds (list[float]): Exceedance thresholds, in the units of the fields
+            (e.g. mm of precip).
+        \b
+        radius (float | list[float]): Neighborhood half-width radius in km. A window
+            of side 2*round(radius/grid_spacing_km)+1 grid points is used. May be a
+            scalar or a list; the output carries a radius dimension.
+        \b
+        grid_spacing_km (float, optional): Grid spacing in km, used to convert radius
+            to grid points. Defaults to 6.0.
+        \b
+        verification_dataset (dict): Config for the gridded verification dataset. Keys:
+            path (str): Path to the zarr store (plain gridded (time, y, x) dataset).
+            precip_varname (str, optional): Name of the precip variable. Defaults to
+                the sole data_var if the dataset has exactly one.
+            trim_edge (dict, optional): Per-axis grid points to trim, e.g.
+                {x: [lo, hi], y: [lo, hi]}, to align with the forecast grid.
+        \b
+        forecast_dataset (dict): Config for the forecast dataset. Keys:
+            model_type (str): The model grid type, e.g. "nested-lam".
+            precip_varname (str): Name of the precip variable in the forecast.
+            lam_index (int, optional): For nested models, the number of grid points
+                belonging to the LAM domain.
+            lcc_info (dict, optional): Lambert Conformal Conic details {n_x, n_y}.
+            trim_forecast_edge (list[int], optional): Additional edge trimming.
+            from_anemoi (bool, optional): Included for parity with other workflows;
+                forecasts are opened via the anemoi inference format.
+        \b
+        start_date (str): The first initial condition date to process.
+        \b
+        end_date (str): The last initial condition date to process.
+        \b
+        freq (str): Frequency string for the date range (e.g., "6h").
+        \b
+        use_mpi (bool, optional): If True, distribute initial conditions across MPI ranks.
+        \b
+        log_path (str, optional): When using MPI, the directory for per-rank log files.
+    """
+
+
+@cli.command()
+@click.argument('config_file', type=click.Path(exists=True))
 def spatial(config_file):
     """
     Compute spatial error metrics.

--- a/src/eagle/tools/cli.py
+++ b/src/eagle/tools/cli.py
@@ -207,7 +207,10 @@ fss.help = """Compute the deterministic Fractions Skill Score (FSS).
         \b
         output_path (str): Directory where the output is saved, as
             f"{output_path}/fss.{model_type}.nc". The result has data_vars
-            fss, mse, mse_ref with dims (t0, fhr, threshold, radius).
+            fss, mse, mse_ref with dims (t0, fhr, threshold, radius). If
+            percentiles are configured, a second file
+            f"{output_path}/fss.percentile.{model_type}.nc" is written with
+            data_vars pfss, pmse, pmse_ref and dims (t0, fhr, percentile, radius).
         \b
         lead_time (int): Forecast length in hours, used only to build the forecast
             filename.
@@ -217,6 +220,15 @@ fss.help = """Compute the deterministic Fractions Skill Score (FSS).
         \b
         thresholds (list[float]): Exceedance thresholds, in the units of the fields
             (e.g. mm of precip).
+        \b
+        percentiles (list[float], optional): If present, additionally compute a
+            percentile-threshold FSS (Roberts & Lean, 2008). Each field is
+            binarized at its own P-th percentile value, quantile(P/100), computed
+            separately for the forecast and observations over valid, wet (> 0) grid
+            points at each lead time (wet-only avoids the dry-mass degeneracy where
+            low percentiles land at 0 mm); deriving the thresholds per field removes
+            rainfall-amount bias to isolate spatial accuracy. If omitted, only
+            threshold FSS is done.
         \b
         radius (float | list[float]): Neighborhood half-width radius in km. A window
             of side 2*round(radius/grid_spacing_km)+1 grid points is used. May be a

--- a/src/eagle/tools/cli.py
+++ b/src/eagle/tools/cli.py
@@ -230,8 +230,8 @@ fss.help = """Compute the deterministic Fractions Skill Score (FSS).
             rainfall-amount bias to isolate spatial accuracy. If omitted, only
             threshold FSS is done.
         \b
-        radius (float | list[float]): Neighborhood half-width radius in km. A window
-            of side 2*round(radius/grid_spacing_km)+1 grid points is used. May be a
+        radius_km (float | list[float]): Neighborhood half-width radius in km. A window
+            of side 2*round(radius_km/grid_spacing_km)+1 grid points is used. May be a
             scalar or a list; the output carries a radius dimension.
         \b
         grid_spacing_km (float, optional): Grid spacing in km, used to convert radius

--- a/src/eagle/tools/data.py
+++ b/src/eagle/tools/data.py
@@ -339,7 +339,7 @@ def open_anemoi_inference_dataset(
     return xds
 
 def open_forecast_zarr_dataset(
-    path: str,
+    path: str | Sequence[str],
     t0: pd.Timestamp,
     levels: Sequence[float | int] = None,
     vars_of_interest: Sequence[str] = None,
@@ -354,7 +354,9 @@ def open_forecast_zarr_dataset(
     Opens non-anemoi forecast datasets (e.g., HRRR forecast data preprocessed by ufs2arco).
 
     Args:
-        path (str): Path to the Zarr dataset.
+        path (str | Sequence[str]): Path to the Zarr dataset. May also be a list of
+            paths, one per lead time, when the forecast was written to a separate
+            store for each forecast hour; the stores are concatenated along ``fhr``.
         t0 (pd.Timestamp): The initialization time to select.
         levels (Sequence[float | int], optional): Vertical levels to select.
         vars_of_interest (Sequence[str], optional): specific variables to keep.
@@ -371,7 +373,13 @@ def open_forecast_zarr_dataset(
         xr.Dataset: The forecast dataset.
     """
 
-    xds = xr.open_zarr(path, decode_timedelta=True)
+    if isinstance(path, (list, tuple)):
+        # One store per lead time: concat along fhr into a single multi-fhr view.
+        xds = xr.concat(
+            [xr.open_zarr(p, decode_timedelta=True) for p in path], dim="fhr"
+        )
+    else:
+        xds = xr.open_zarr(path, decode_timedelta=True)
     stack_order = list(x for x in xds.dims if x not in ["t0", "fhr", "level", "member"])
     xds = xds.sel(t0=t0).squeeze(drop=True)
     xds["time"] = xr.DataArray(

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -64,6 +64,33 @@ def _neighborhood_fraction(binary, valid, size):
     return num / den.where(den > eps)
 
 
+def _fss_from_binaries(fbin, obin, valid, radii_gp):
+    """Compute FSS from pre-built binary exceedance fields, looping over radii.
+
+    Shared core for both the threshold and percentile variants: they differ only
+    in how ``fbin``/``obin`` are constructed. Any extra dims carried on the
+    binaries (e.g. ``threshold`` or ``percentile``) pass straight through.
+
+    Returns:
+        xr.Dataset: ``fss``, ``mse``, ``mse_ref`` with dims
+        ``(<extra dims>, radius)``.
+    """
+    per_radius = []
+    for radius_km, size in radii_gp:
+        M = _neighborhood_fraction(fbin, valid, size)
+        O = _neighborhood_fraction(obin, valid, size)
+
+        mse = ((M - O) ** 2).mean(("y", "x"))
+        mse_ref = (M**2 + O**2).mean(("y", "x"))
+        fss = 1 - mse / mse_ref.where(mse_ref > 0)
+
+        ds = xr.Dataset({"fss": fss, "mse": mse, "mse_ref": mse_ref})
+        ds = ds.expand_dims(radius=[radius_km])
+        per_radius.append(ds)
+
+    return xr.concat(per_radius, dim="radius")
+
+
 def fractions_skill_score(fcst, obs, thresholds, radii_gp):
     """Deterministic Fractions Skill Score (Roberts & Lean, 2008).
 
@@ -84,20 +111,48 @@ def fractions_skill_score(fcst, obs, thresholds, radii_gp):
     fbin = ((fcst >= txda) & (valid > 0)).astype(float)
     obin = ((obs >= txda) & (valid > 0)).astype(float)
 
-    per_radius = []
-    for radius_km, size in radii_gp:
-        M = _neighborhood_fraction(fbin, valid, size)
-        O = _neighborhood_fraction(obin, valid, size)
+    return _fss_from_binaries(fbin, obin, valid, radii_gp)
 
-        mse = ((M - O) ** 2).mean(("y", "x"))
-        mse_ref = (M**2 + O**2).mean(("y", "x"))
-        fss = 1 - mse / mse_ref.where(mse_ref > 0)
 
-        ds = xr.Dataset({"fss": fss, "mse": mse, "mse_ref": mse_ref})
-        ds = ds.expand_dims(radius=[radius_km])
-        per_radius.append(ds)
+def fractions_skill_score_percentile(fcst, obs, percentiles, radii_gp):
+    """Percentile-threshold Fractions Skill Score (Roberts & Lean, 2008).
 
-    return xr.concat(per_radius, dim="radius")
+    Each field is binarized at its own ``P``-th percentile (``quantile(P/100)``),
+    computed independently for the forecast and observations over the valid,
+    *wet* (``> 0``) grid points at each lead time. Deriving the thresholds per
+    field removes any rainfall-amount bias, isolating spatial accuracy.
+
+    The percentile is taken over wet points only because precipitation has a
+    large dry (zero) point-mass: including it would put the low/mid percentiles
+    exactly at 0 mm, so ``field >= 0`` would flag every cell and the score would
+    collapse to ~1. Over wet points, ``P=50`` is the median of the *raining*
+    cells. The exceedance test itself still uses all valid points.
+
+    Args:
+        fcst, obs (xr.DataArray): forecast and verification fields with dims
+            ``(fhr, y, x)``.
+        percentiles (Sequence[float]): percentile ranks in ``[0, 100]``.
+        radii_gp (Sequence[tuple[float, int]]): ``(radius_km, window_size)`` pairs.
+
+    Returns:
+        xr.Dataset: ``pfss``, ``pmse``, ``pmse_ref`` with dims
+        ``(fhr, percentile, radius)``.
+    """
+    valid = (np.isfinite(fcst) & np.isfinite(obs)).astype(float)
+
+    # Per-field exceedance values from the valid, wet (> 0) points only, one per
+    # (fhr, P). Excluding the dry mass keeps low/mid percentiles meaningful.
+    qs = [p / 100 for p in percentiles]
+    fq = fcst.where((valid > 0) & (fcst > 0)).quantile(qs, dim=("y", "x"))
+    oq = obs.where((valid > 0) & (obs > 0)).quantile(qs, dim=("y", "x"))
+    fq = fq.rename({"quantile": "percentile"}).assign_coords(percentile=list(percentiles))
+    oq = oq.rename({"quantile": "percentile"}).assign_coords(percentile=list(percentiles))
+
+    fbin = ((fcst >= fq) & (valid > 0)).astype(float)
+    obin = ((obs >= oq) & (valid > 0)).astype(float)
+
+    ds = _fss_from_binaries(fbin, obin, valid, radii_gp)
+    return ds.rename({"fss": "pfss", "mse": "pmse", "mse_ref": "pmse_ref"})
 
 
 #: Order in which the per-axis ``trim_edge`` dict is flattened for
@@ -188,11 +243,12 @@ def main(config):
 
     forecast_hours = config["forecast_hours"]
     thresholds = config["thresholds"]
+    percentiles = config.get("percentiles", None)
     grid_spacing_km = config["grid_spacing_km"]
     radii_gp = _radii_in_gridpoints(config["radius"], grid_spacing_km)
 
     logger.info(
-        f"FSS setup: thresholds={thresholds}, "
+        f"FSS setup: thresholds={thresholds}, percentiles={percentiles}, "
         f"radii (km, window)={radii_gp}, forecast_hours={forecast_hours}"
     )
 
@@ -224,6 +280,7 @@ def main(config):
     n_batches = int(np.ceil(n_dates / topo.size))
 
     container = []
+    pcontainer = [] if percentiles is not None else None
 
     logger.info("Computing Fractions Skill Score")
     logger.info(f"Initial Conditions:\n{dates}")
@@ -299,29 +356,43 @@ def main(config):
         fcst = fcst.rename({"time": "fhr"}).assign_coords(fhr=fhr)
         obs = obs.rename({"time": "fhr"}).assign_coords(fhr=fhr)
 
-        result = fractions_skill_score(fcst, obs, thresholds, radii_gp)
+        # Per-IC coords: keep t0 so the full (t0, fhr, ..., radius) sample is
+        # retained for aggregation and significance testing downstream.
+        lead_coord = (fhr * np.timedelta64(1, "h")).astype("timedelta64[ns]")
 
-        # Per-IC coords: keep t0 so the full (t0, fhr, threshold, radius) sample
-        # is retained for aggregation and significance testing downstream.
-        result = result.expand_dims(t0=[t0])
-        result = result.assign_coords(
-            lead_time=("fhr", (fhr * np.timedelta64(1, "h")).astype("timedelta64[ns]"))
-        )
+        def _tag(ds):
+            return ds.expand_dims(t0=[t0]).assign_coords(lead_time=("fhr", lead_coord))
+
+        result = _tag(fractions_skill_score(fcst, obs, thresholds, radii_gp))
         container.append(result)
+
+        if percentiles is not None:
+            presult = _tag(
+                fractions_skill_score_percentile(fcst, obs, percentiles, radii_gp)
+            )
+            pcontainer.append(presult)
 
         logger.info(f"Done with {st0}")
     logger.info("Done Computing FSS")
 
     logger.info("Gathering Results on Root Process")
     container = topo.gather(container)
+    if percentiles is not None:
+        pcontainer = topo.gather(pcontainer)
+
+    def _combine_and_store(gathered, fname):
+        if config["use_mpi"]:
+            gathered = [xds for sublist in gathered for xds in sublist]
+        gathered = sorted(gathered, key=lambda xds: xds.coords["t0"].values)
+        xr.concat(gathered, dim="t0").to_netcdf(fname)
+        logger.info(f"Stored result: {fname}")
 
     if topo.is_root:
         logger.info("Combining & Storing Results")
-        if config["use_mpi"]:
-            container = [xds for sublist in container for xds in sublist]
-        container = sorted(container, key=lambda xds: xds.coords["t0"].values)
-        result = xr.concat(container, dim="t0")
-        fname = f"{config['output_path']}/fss.{model_type}.nc"
-        result.to_netcdf(fname)
-        logger.info(f"Stored result: {fname}")
+        _combine_and_store(container, f"{config['output_path']}/fss.{model_type}.nc")
+        if percentiles is not None:
+            _combine_and_store(
+                pcontainer,
+                f"{config['output_path']}/fss.percentile.{model_type}.nc",
+            )
         logger.info("Done Storing FSS")

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -6,6 +6,8 @@ from scipy import ndimage
 import xarray as xr
 import pandas as pd
 
+from ufs2arco.transforms.horizontal_regrid import horizontal_regrid
+
 from eagle.tools.data import (
     open_anemoi_inference_dataset,
     open_forecast_zarr_dataset,
@@ -235,11 +237,15 @@ def main(config):
     fcfg = config["forecast_dataset"]
 
     model_type = fcfg["model_type"]
+    if model_type == "nested-global":
+        raise NotImplementedError
     fcst_precip = fcfg["precip_varname"]
     lam_index = fcfg.get("lam_index", None)
     lcc_info = fcfg.get("lcc_info", None)
     from_anemoi = fcfg.get("from_anemoi", True)
     trim_forecast_edge = fcfg.get("trim_edge", None)
+    forecast_regrid_kwargs = fcfg.get("regrid_kwargs", None)
+    trim_after_regrid = fcfg.get("trim_after_regrid", None)
 
     forecast_hours = config["forecast_hours"]
     thresholds = config["thresholds"]
@@ -330,7 +336,30 @@ def main(config):
                 lcc_info=lcc_info,
                 load=True,
             )
+
         fds = fds.rename({fcst_precip: PRECIP})
+
+        if forecast_regrid_kwargs is not None:
+            fds = horizontal_regrid(fds, **forecast_regrid_kwargs)
+
+        # Optionally trim the forecast edges after regridding (e.g. to drop
+        # conservative-regridding boundary artifacts on the target grid). The
+        # regridded grid carries only 2D lat/lon coords, so give it integer x/y
+        # index coords for trim_xarray_edge to slice on. The verification and
+        # mask must be trimmed to match via verification_dataset.trim_edge; the
+        # (y, x) size assertion below enforces that alignment.
+        if trim_after_regrid is not None:
+            if "x" not in fds.coords or "y" not in fds.coords:
+                fds = fds.assign_coords(
+                    x=("x", np.arange(fds.sizes["x"])),
+                    y=("y", np.arange(fds.sizes["y"])),
+                )
+            fds = trim_xarray_edge(
+                fds,
+                lcc_info=lcc_info,
+                trim_edge=trim_after_regrid,
+                stack_order=list(STACK_ORDER),
+            )
 
         # Select the requested lead times and matching verification valid times
         target_times = [t0 + pd.Timedelta(hours=h) for h in forecast_hours]

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -1,0 +1,289 @@
+import logging
+
+import numpy as np
+from scipy import ndimage
+import xarray as xr
+import pandas as pd
+
+from eagle.tools.data import open_anemoi_inference_dataset, trim_xarray_edge
+
+logger = logging.getLogger("eagle.tools")
+
+# Common name given to the precip variable in both datasets so they can be
+# compared directly regardless of their original variable names.
+PRECIP = "precip"
+
+
+def _uniform_filter_lastdims(arr, size):
+    """Apply a square uniform (box) filter over the trailing two axes only.
+
+    ``scipy.ndimage.uniform_filter`` is separable and runs in O(N) regardless
+    of window size, which is what makes FSS cheap for large neighborhoods. We
+    filter the trailing ``(y, x)`` axes and leave any leading broadcast axes
+    (fhr, threshold) untouched via a size of 1 on those axes.
+    """
+    fsize = (1,) * (arr.ndim - 2) + (size, size)
+    return ndimage.uniform_filter(arr, size=fsize, mode="constant", cval=0.0)
+
+
+def _box_mean(da, size):
+    """Neighborhood (box) mean over the (y, x) core dims, keeping other dims."""
+    return xr.apply_ufunc(
+        _uniform_filter_lastdims,
+        da,
+        input_core_dims=[["y", "x"]],
+        output_core_dims=[["y", "x"]],
+        kwargs={"size": size},
+    )
+
+
+def _neighborhood_fraction(binary, valid, size):
+    """Mask-aware fraction of valid points exceeding the threshold in each window.
+
+    ``uniform_filter`` normalizes by the full window count, so dividing the
+    filtered ``binary*valid`` by the filtered ``valid`` recovers
+    (exceedances / valid points) within each window. This shrinks the window at
+    the domain edge and around any NaNs, matching Roberts & Lean's in-domain
+    fraction. Windows with no valid points become NaN and are skipped later.
+    """
+    num = _box_mean(binary * valid, size)
+    den = _box_mean(valid, size)
+    return num / den.where(den > 0)
+
+
+def fractions_skill_score(fcst, obs, thresholds, radii_gp):
+    """Deterministic Fractions Skill Score (Roberts & Lean, 2008).
+
+    Args:
+        fcst, obs (xr.DataArray): forecast and verification fields with dims
+            ``(fhr, y, x)``.
+        thresholds (Sequence[float]): exceedance thresholds (same units as the fields).
+        radii_gp (Sequence[tuple[float, int]]): ``(radius_km, window_size)`` pairs,
+            where ``window_size = 2*n+1`` grid points.
+
+    Returns:
+        xr.Dataset: ``fss``, ``mse``, ``mse_ref`` with dims ``(fhr, threshold, radius)``.
+    """
+    txda = xr.DataArray(
+        list(thresholds), dims="threshold", coords={"threshold": list(thresholds)}
+    )
+    valid = (np.isfinite(fcst) & np.isfinite(obs)).astype(float)
+    fbin = ((fcst >= txda) & (valid > 0)).astype(float)
+    obin = ((obs >= txda) & (valid > 0)).astype(float)
+
+    per_radius = []
+    for radius_km, size in radii_gp:
+        M = _neighborhood_fraction(fbin, valid, size)
+        O = _neighborhood_fraction(obin, valid, size)
+
+        mse = ((M - O) ** 2).mean(("y", "x"))
+        mse_ref = (M**2 + O**2).mean(("y", "x"))
+        fss = 1 - mse / mse_ref.where(mse_ref > 0)
+
+        ds = xr.Dataset({"fss": fss, "mse": mse, "mse_ref": mse_ref})
+        ds = ds.expand_dims(radius=[radius_km])
+        per_radius.append(ds)
+
+    return xr.concat(per_radius, dim="radius")
+
+
+#: Order in which the per-axis ``trim_edge`` dict is flattened for
+#: ``trim_xarray_edge``. AORC/mask arrays are stored ``(..., y, x)``.
+STACK_ORDER = ("y", "x")
+
+
+def _open_verification(path, precip_varname, lcc_info, trim_edge=None):
+    """Open the gridded verification dataset (e.g. AORC), select & rename precip.
+
+    AORC is a plain gridded zarr with ``(time, y, x)`` dims (not an anemoi
+    dataset), so it is opened directly and trimmed via ``trim_xarray_edge``.
+    """
+    xds = xr.open_zarr(path)
+    if precip_varname is None:
+        data_vars = list(xds.data_vars)
+        assert len(data_vars) == 1, (
+            f"verification precip_varname not set and {path} has multiple "
+            f"data_vars: {data_vars}"
+        )
+        precip_varname = data_vars[0]
+    xds = xds[[precip_varname]].rename({precip_varname: PRECIP})
+    if trim_edge is not None:
+        xds = trim_xarray_edge(
+            xds,
+            lcc_info=lcc_info,
+            trim_edge=trim_edge,
+            stack_order=list(STACK_ORDER),
+        )
+    return xds
+
+
+def _open_mask(path, varname, lcc_info, trim_edge=None):
+    """Open the verification validity mask, trim it, and binarize.
+
+    The mask is a static ``(y, x)`` field flagging where the verification
+    dataset is valid. It is stored with float/bool values; ``mask > 0`` gives
+    the boolean "valid" field. It lives on the untrimmed verification grid, so
+    the same ``trim_edge`` is applied to co-register it (and reset its coords to
+    start at 0) to match the trimmed forecast/verification fields.
+    """
+    xds = xr.open_dataset(path)[[varname]]
+    if trim_edge is not None:
+        xds = trim_xarray_edge(
+            xds,
+            lcc_info=lcc_info,
+            trim_edge=trim_edge,
+            stack_order=list(STACK_ORDER),
+        )
+    return xds[varname] > 0
+
+
+def _radii_in_gridpoints(radius, grid_spacing_km):
+    """Convert (half-width) radii in km to ``(radius_km, window_size)`` pairs.
+
+    ``radius`` may be a scalar or a list. ``n = round(radius / dx)`` and the
+    square window side is ``2*n + 1`` grid points.
+    """
+    radii = radius if isinstance(radius, (list, tuple)) else [radius]
+    out = []
+    for r in radii:
+        n = int(round(r / grid_spacing_km))
+        out.append((r, 2 * n + 1))
+    return out
+
+
+def main(config):
+    """Compute the deterministic Fractions Skill Score.
+
+    See ``eagle-tools fss --help`` or cli.py for help
+    """
+    if isinstance(config, str):
+        from eagle.tools.utils import setup
+
+        config = setup(config, "fss")
+
+    topo = config["topo"]
+
+    vcfg = config["verification_dataset"]
+    fcfg = config["forecast_dataset"]
+
+    model_type = fcfg["model_type"]
+    fcst_precip = fcfg["precip_varname"]
+    lam_index = fcfg.get("lam_index", None)
+    lcc_info = fcfg.get("lcc_info", None)
+    trim_forecast_edge = fcfg.get("trim_forecast_edge", None)
+
+    forecast_hours = config["forecast_hours"]
+    thresholds = config["thresholds"]
+    grid_spacing_km = config["grid_spacing_km"]
+    radii_gp = _radii_in_gridpoints(config["radius"], grid_spacing_km)
+
+    logger.info(
+        f"FSS setup: thresholds={thresholds}, "
+        f"radii (km, window)={radii_gp}, forecast_hours={forecast_hours}"
+    )
+
+    # Verification dataset opened once, lazily
+    vds = _open_verification(
+        path=vcfg["path"],
+        precip_varname=vcfg.get("precip_varname", None),
+        lcc_info=lcc_info,
+        trim_edge=vcfg.get("trim_edge", None),
+    )
+
+    # Optional validity mask (where the verification dataset is valid). Applied
+    # to the forecast so invalid points are ignored in every comparison.
+    mask = None
+    if vcfg.get("mask", None) is not None:
+        mcfg = vcfg["mask"]
+        mask = _open_mask(
+            path=mcfg["path"],
+            varname=mcfg["varname"],
+            lcc_info=lcc_info,
+            trim_edge=vcfg.get("trim_edge", None),
+        ).load()
+        logger.info(
+            f"Loaded verification mask (valid fraction={float(mask.mean()):.3f})"
+        )
+
+    dates = pd.date_range(config["start_date"], config["end_date"], freq=config["freq"])
+    n_dates = len(dates)
+    n_batches = int(np.ceil(n_dates / topo.size))
+
+    container = []
+
+    logger.info("Computing Fractions Skill Score")
+    logger.info(f"Initial Conditions:\n{dates}")
+    for batch_idx in range(n_batches):
+
+        date_idx = (batch_idx * topo.size) + topo.rank
+        if date_idx + 1 > n_dates:
+            break  # last batch situation
+
+        t0 = dates[date_idx]
+        st0 = t0.strftime("%Y-%m-%dT%H")
+        logger.info(f"Processing {st0}")
+
+        # Load forecast, reshaped to (time, y, x)
+        fname = f"{config['forecast_path']}/{st0}.{config['lead_time']}h.nc"
+        fds = open_anemoi_inference_dataset(
+            fname,
+            model_type=model_type,
+            lam_index=lam_index,
+            lcc_info=lcc_info,
+            trim_edge=trim_forecast_edge,
+            vars_of_interest=[fcst_precip],
+            reshape_cell_to_2d=True,
+            load=True,
+        )
+        fds = fds.rename({fcst_precip: PRECIP})
+
+        # Select the requested lead times and matching verification valid times
+        target_times = [t0 + pd.Timedelta(hours=h) for h in forecast_hours]
+        fcst = fds[PRECIP].sel(time=target_times)
+        obs = vds[PRECIP].sel(time=target_times).load()
+
+        assert fcst.sizes["y"] == obs.sizes["y"] and fcst.sizes["x"] == obs.sizes["x"], (
+            f"Forecast (y,x)=({fcst.sizes['y']},{fcst.sizes['x']}) and verification "
+            f"(y,x)=({obs.sizes['y']},{obs.sizes['x']}) grids do not match"
+        )
+
+        # Mask out points where the verification is invalid, so they are
+        # excluded from the neighborhood fractions (via the finite check).
+        if mask is not None:
+            assert mask.sizes["y"] == fcst.sizes["y"] and mask.sizes["x"] == fcst.sizes["x"], (
+                f"Mask (y,x)=({mask.sizes['y']},{mask.sizes['x']}) and forecast "
+                f"(y,x)=({fcst.sizes['y']},{fcst.sizes['x']}) grids do not match"
+            )
+            fcst = fcst.where(mask)
+
+        # Replace the datetime time dim with integer forecast hour
+        fhr = np.array(forecast_hours, dtype=int)
+        fcst = fcst.rename({"time": "fhr"}).assign_coords(fhr=fhr)
+        obs = obs.rename({"time": "fhr"}).assign_coords(fhr=fhr)
+
+        result = fractions_skill_score(fcst, obs, thresholds, radii_gp)
+
+        # Per-IC coords: keep t0 so the full (t0, fhr, threshold, radius) sample
+        # is retained for aggregation and significance testing downstream.
+        result = result.expand_dims(t0=[t0])
+        result = result.assign_coords(
+            lead_time=("fhr", (fhr * np.timedelta64(1, "h")).astype("timedelta64[ns]"))
+        )
+        container.append(result)
+
+        logger.info(f"Done with {st0}")
+    logger.info("Done Computing FSS")
+
+    logger.info("Gathering Results on Root Process")
+    container = topo.gather(container)
+
+    if topo.is_root:
+        logger.info("Combining & Storing Results")
+        if config["use_mpi"]:
+            container = [xds for sublist in container for xds in sublist]
+        container = sorted(container, key=lambda xds: xds.coords["t0"].values)
+        result = xr.concat(container, dim="t0")
+        fname = f"{config['output_path']}/fss.{model_type}.nc"
+        result.to_netcdf(fname)
+        logger.info(f"Stored result: {fname}")
+        logger.info("Done Storing FSS")

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -45,10 +45,18 @@ def _neighborhood_fraction(binary, valid, size):
     (exceedances / valid points) within each window. This shrinks the window at
     the domain edge and around any NaNs, matching Roberts & Lean's in-domain
     fraction. Windows with no valid points become NaN and are skipped later.
+
+    ``den`` is a fraction in [0, 1]; the smallest *legitimate* nonzero value is
+    ``1 / size**2`` (a single valid cell in the window). ``uniform_filter``
+    leaves ~1e-15 roundoff where the true value is zero, so we threshold at half
+    the smallest real fraction. A plain ``den > 0`` guard would instead let tiny
+    positive roundoff through and divide near-zero ``num`` by it, yielding wild
+    (even negative) "fractions" that corrupt the score.
     """
     num = _box_mean(binary * valid, size)
     den = _box_mean(valid, size)
-    return num / den.where(den > 0)
+    eps = 0.5 / (size * size)
+    return num / den.where(den > eps)
 
 
 def fractions_skill_score(fcst, obs, thresholds, radii_gp):

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 import numpy as np
 from scipy import ndimage
@@ -252,8 +253,19 @@ def main(config):
                 load=True,
             )
         else:
+            # A single forecast zarr, or (when lead_time is a list) one store
+            # per lead time whose paths come from a ``{fhr:02d}`` template and
+            # are concatenated along fhr.
+            lead_time = config["lead_time"]
+            if isinstance(lead_time, (list, tuple)):
+                fpath = [
+                    os.path.expandvars(config["forecast_path"].format(fhr=h))
+                    for h in lead_time
+                ]
+            else:
+                fpath = config["forecast_path"]
             fds = open_forecast_zarr_dataset(
-                config["forecast_path"],
+                fpath,
                 t0=t0,
                 vars_of_interest=[fcst_precip],
                 trim_edge=trim_forecast_edge,

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -245,7 +245,7 @@ def main(config):
     thresholds = config["thresholds"]
     percentiles = config.get("percentiles", None)
     grid_spacing_km = config["grid_spacing_km"]
-    radii_gp = _radii_in_gridpoints(config["radius"], grid_spacing_km)
+    radii_gp = _radii_in_gridpoints(config["radius_km"], grid_spacing_km)
 
     logger.info(
         f"FSS setup: thresholds={thresholds}, percentiles={percentiles}, "

--- a/src/eagle/tools/fss.py
+++ b/src/eagle/tools/fss.py
@@ -5,7 +5,11 @@ from scipy import ndimage
 import xarray as xr
 import pandas as pd
 
-from eagle.tools.data import open_anemoi_inference_dataset, trim_xarray_edge
+from eagle.tools.data import (
+    open_anemoi_inference_dataset,
+    open_forecast_zarr_dataset,
+    trim_xarray_edge,
+)
 
 logger = logging.getLogger("eagle.tools")
 
@@ -178,7 +182,8 @@ def main(config):
     fcst_precip = fcfg["precip_varname"]
     lam_index = fcfg.get("lam_index", None)
     lcc_info = fcfg.get("lcc_info", None)
-    trim_forecast_edge = fcfg.get("trim_forecast_edge", None)
+    from_anemoi = fcfg.get("from_anemoi", True)
+    trim_forecast_edge = fcfg.get("trim_edge", None)
 
     forecast_hours = config["forecast_hours"]
     thresholds = config["thresholds"]
@@ -231,18 +236,31 @@ def main(config):
         st0 = t0.strftime("%Y-%m-%dT%H")
         logger.info(f"Processing {st0}")
 
-        # Load forecast, reshaped to (time, y, x)
-        fname = f"{config['forecast_path']}/{st0}.{config['lead_time']}h.nc"
-        fds = open_anemoi_inference_dataset(
-            fname,
-            model_type=model_type,
-            lam_index=lam_index,
-            lcc_info=lcc_info,
-            trim_edge=trim_forecast_edge,
-            vars_of_interest=[fcst_precip],
-            reshape_cell_to_2d=True,
-            load=True,
-        )
+        # Load forecast, reshaped to (time, y, x). Either an anemoi inference
+        # NetCDF (one file per initial condition) or a forecast zarr store
+        # holding all initial conditions along a t0 dim.
+        if from_anemoi:
+            fname = f"{config['forecast_path']}/{st0}.{config['lead_time']}h.nc"
+            fds = open_anemoi_inference_dataset(
+                fname,
+                model_type=model_type,
+                lam_index=lam_index,
+                lcc_info=lcc_info,
+                trim_edge=trim_forecast_edge,
+                vars_of_interest=[fcst_precip],
+                reshape_cell_to_2d=True,
+                load=True,
+            )
+        else:
+            fds = open_forecast_zarr_dataset(
+                config["forecast_path"],
+                t0=t0,
+                vars_of_interest=[fcst_precip],
+                trim_edge=trim_forecast_edge,
+                reshape_cell_to_2d=True,
+                lcc_info=lcc_info,
+                load=True,
+            )
         fds = fds.rename({fcst_precip: PRECIP})
 
         # Select the requested lead times and matching verification valid times


### PR DESCRIPTION
New workflow to compute fractions skill score. By default, it computes FSS vs quantity thresholds (e.g. if datasets are in mm, then thresholds are in mm). But, users can ask for percentiles and get that too.

TODO:
- [ ] Add a sample config
- [ ] Generalize the multi-dataset join that I used to combine the HRRR datasets
- [ ] Give it a once over 
- [ ] Make some notes about guarding against 0 rain when computing neighborhood fraction